### PR TITLE
Add tests for filters added in Shopify/Liquid 5.7.0

### DIFF
--- a/golden_liquid.json
+++ b/golden_liquid.json
@@ -8295,6 +8295,164 @@
                     "partials": {},
                     "error": false,
                     "strict": false
+                },
+                {
+                    "name": "property with a dot, path match",
+                    "template": "{% assign sorted = a | sort_natural: 'foo.bar' -%}\n{% for item in sorted -%}\n{% for pair in item.foo -%}\n({{ pair[0] }}, {{ pair[1] }})\n{% endfor -%}\n{% endfor %}",
+                    "want": "(bar, a)\n(bar, A)\n(bar, b)\n(bar, B)\n(bar, C)\n",
+                    "context": {
+                        "a": [
+                            {
+                                "foo": {
+                                    "bar": "b"
+                                }
+                            },
+                            {
+                                "foo": {
+                                    "bar": "a"
+                                }
+                            },
+                            {
+                                "foo": {
+                                    "bar": "C"
+                                }
+                            },
+                            {
+                                "foo": {
+                                    "bar": "B"
+                                }
+                            },
+                            {
+                                "foo": {
+                                    "bar": "A"
+                                }
+                            }
+                        ]
+                    },
+                    "partials": {},
+                    "error": false,
+                    "strict": false
+                },
+                {
+                    "name": "property with a dot, string and path match",
+                    "template": "{% assign sorted = a | sort_natural: 'foo.bar' -%}\n{% for item in sorted -%}\n{% for pair in item -%}\n({{ pair[0] }}, \n{%- if pair[1].bar -%}\n{{ pair[1].bar }}{%else%}{{ pair[1] -}}\n{% endif %})\n{% endfor -%}\n{% endfor %}",
+                    "want": "(foo,a)\n(foo,A)\n(foo.bar,b)\n(foo,B)\n(foo,C)\n",
+                    "context": {
+                        "a": [
+                            {
+                                "foo.bar": "b"
+                            },
+                            {
+                                "foo": {
+                                    "bar": "a"
+                                }
+                            },
+                            {
+                                "foo": {
+                                    "bar": "C"
+                                }
+                            },
+                            {
+                                "foo": {
+                                    "bar": "B"
+                                }
+                            },
+                            {
+                                "foo": {
+                                    "bar": "A"
+                                }
+                            }
+                        ]
+                    },
+                    "partials": {},
+                    "error": false,
+                    "strict": false
+                },
+                {
+                    "name": "property with a dot, string match",
+                    "template": "{% assign sorted = a | sort_natural: 'foo.bar' -%}\n{% for item in sorted -%}\n{% for pair in item -%}\n({{ pair[0] }}, {{ pair[1] }})\n{% endfor -%}\n{% endfor %}",
+                    "want": "(foo.bar, a)\n(foo.bar, A)\n(foo.bar, b)\n(foo.bar, B)\n(foo.bar, C)\n",
+                    "context": {
+                        "a": [
+                            {
+                                "foo.bar": "b"
+                            },
+                            {
+                                "foo.bar": "a"
+                            },
+                            {
+                                "foo.bar": "C"
+                            },
+                            {
+                                "foo.bar": "B"
+                            },
+                            {
+                                "foo.bar": "A"
+                            }
+                        ]
+                    },
+                    "partials": {},
+                    "error": false,
+                    "strict": false
+                },
+                {
+                    "name": "property, array contains array",
+                    "template": "{% assign sorted = a | sort_natural: 'foo' -%}\n{% for item in sorted -%}\n{% for pair in item -%}\n({{ pair[0] }}, {{ pair[1] }})\n{% endfor -%}\n{% endfor %}",
+                    "want": "",
+                    "context": {
+                        "a": [
+                            {
+                                "foo": "b"
+                            },
+                            {
+                                "foo": "a"
+                            },
+                            {
+                                "foo": "C"
+                            },
+                            {
+                                "foo": "B"
+                            },
+                            {
+                                "foo": "A"
+                            },
+                            [
+                                42,
+                                7
+                            ]
+                        ]
+                    },
+                    "partials": {},
+                    "error": false,
+                    "strict": false
+                },
+                {
+                    "name": "property, array contains primitive",
+                    "template": "{% assign sorted = a | sort_natural: 'foo' -%}\n{% for item in sorted -%}\n{% for pair in item -%}\n({{ pair[0] }}, {{ pair[1] }})\n{% endfor -%}\n{% endfor %}",
+                    "want": "",
+                    "context": {
+                        "a": [
+                            {
+                                "foo": "b"
+                            },
+                            {
+                                "foo": "a"
+                            },
+                            {
+                                "foo": "C"
+                            },
+                            {
+                                "foo": "B"
+                            },
+                            {
+                                "foo": "A"
+                            },
+                            false
+                        ]
+                    },
+                    "partials": {},
+                    "error": false,
+                    "strict": false
                 }
             ]
         },
@@ -9664,6 +9822,163 @@
                     "template": "{{ nosuchthing | uniq | join: '#' }}",
                     "want": "",
                     "context": {},
+                    "partials": {},
+                    "error": false,
+                    "strict": false
+                },
+                {
+                    "name": "property with a dot, string match",
+                    "template": "{% assign x = a | uniq: 'user.title' %}{% for obj in x %}{% for i in obj %}({{ i[0] }},{{ i[1] }}){% endfor %}{% endfor %}",
+                    "want": "(user.title,foo)(name,a)(user.title,bar)(name,c)",
+                    "context": {
+                        "a": [
+                            {
+                                "user.title": "foo",
+                                "name": "a"
+                            },
+                            {
+                                "user.title": "foo",
+                                "name": "b"
+                            },
+                            {
+                                "user.title": "bar",
+                                "name": "c"
+                            }
+                        ]
+                    },
+                    "partials": {},
+                    "error": false,
+                    "strict": false
+                },
+                {
+                    "name": "property with bracketed index",
+                    "template": "{% assign x = a | uniq: 'foo[1]' -%}\n{% for item in x -%}\n{% for pair in item -%}\n({{ pair[0] }}, {{ pair[1] | join: '#' }})\n{% endfor -%}\n{% endfor %}",
+                    "want": "(foo, 3#4#5)\n",
+                    "context": {
+                        "a": [
+                            {
+                                "foo": [
+                                    3,
+                                    4,
+                                    5
+                                ]
+                            },
+                            {
+                                "foo": [
+                                    3,
+                                    2,
+                                    5
+                                ]
+                            },
+                            {
+                                "foo": [
+                                    3,
+                                    9,
+                                    5
+                                ]
+                            },
+                            {
+                                "foo": [
+                                    3,
+                                    -1,
+                                    5
+                                ]
+                            }
+                        ]
+                    },
+                    "partials": {},
+                    "error": false,
+                    "strict": false
+                },
+                {
+                    "name": "property, array contains a primitive",
+                    "template": "{% assign x = a | uniq: 'title' %}{% for obj in x %}{% for i in obj %}({{ i[0] }},{{ i[1] }}){% endfor %}{% endfor %}",
+                    "want": "",
+                    "context": {
+                        "a": [
+                            {
+                                "title": "foo",
+                                "name": "a"
+                            },
+                            {
+                                "title": "foo",
+                                "name": "b"
+                            },
+                            {
+                                "title": "bar",
+                                "name": "c"
+                            },
+                            false
+                        ]
+                    },
+                    "partials": {},
+                    "error": false,
+                    "strict": false
+                },
+                {
+                    "name": "property, array contains an array",
+                    "template": "{% assign x = a | uniq: 'title' %}{% for obj in x %}{% for i in obj %}({{ i[0] }},{{ i[1] }}){% endfor %}{% endfor %}",
+                    "want": "(title,foo)(name,a)(title,bar)(name,c)(,)",
+                    "context": {
+                        "a": [
+                            {
+                                "title": "foo",
+                                "name": "a"
+                            },
+                            {
+                                "title": "foo",
+                                "name": "b"
+                            },
+                            {
+                                "title": "bar",
+                                "name": "c"
+                            },
+                            [
+                                "foo",
+                                "bar"
+                            ]
+                        ]
+                    },
+                    "partials": {},
+                    "error": false,
+                    "strict": false
+                },
+                {
+                    "name": "property, uniq arrays is a no op",
+                    "template": "{% assign x = a | uniq: 'foo' -%}\n{% for item in x -%}\n{% for pair in item -%}\n({{ pair[0] }}, {{ pair[1] | join: '#' }})\n{% endfor -%}\n{% endfor %}",
+                    "want": "(foo, 3#4#5)\n(foo, 3#2#5)\n(foo, 3#-1#5)\n",
+                    "context": {
+                        "a": [
+                            {
+                                "foo": [
+                                    3,
+                                    4,
+                                    5
+                                ]
+                            },
+                            {
+                                "foo": [
+                                    3,
+                                    2,
+                                    5
+                                ]
+                            },
+                            {
+                                "foo": [
+                                    3,
+                                    4,
+                                    5
+                                ]
+                            },
+                            {
+                                "foo": [
+                                    3,
+                                    -1,
+                                    5
+                                ]
+                            }
+                        ]
+                    },
                     "partials": {},
                     "error": false,
                     "strict": false

--- a/golden_liquid.json
+++ b/golden_liquid.json
@@ -1210,30 +1210,6 @@
             "name": "liquid.golden.compact_filter",
             "tests": [
                 {
-                    "name": "array of objects with key property",
-                    "template": "{% assign x = a | compact: 'title' %}{% for obj in x %}{% for i in obj %}({{ i[0] }},{{ i[1] }}){% endfor %}{% endfor %}",
-                    "want": "(title,foo)(name,a)(title,bar)(name,c)",
-                    "context": {
-                        "a": [
-                            {
-                                "title": "foo",
-                                "name": "a"
-                            },
-                            {
-                                "title": null,
-                                "name": "b"
-                            },
-                            {
-                                "title": "bar",
-                                "name": "c"
-                            }
-                        ]
-                    },
-                    "partials": {},
-                    "error": false,
-                    "strict": false
-                },
-                {
                     "name": "array with a nil",
                     "template": "{{ a | compact | join: '#' }}",
                     "want": "b#a#A",
@@ -1243,6 +1219,60 @@
                             "a",
                             null,
                             "A"
+                        ]
+                    },
+                    "partials": {},
+                    "error": false,
+                    "strict": false
+                },
+                {
+                    "name": "dotted property, path match",
+                    "template": "{% assign x = a | compact: 'user.title' %}{% for obj in x %}{% for i in obj %}({{ i[0] }},{{ i[1].title }},{{ i[1].name }}){% endfor %}{% endfor %}",
+                    "want": "(user,foo,a)(user,bar,c)",
+                    "context": {
+                        "a": [
+                            {
+                                "user": {
+                                    "title": "foo",
+                                    "name": "a"
+                                }
+                            },
+                            {
+                                "user": {
+                                    "title": null,
+                                    "name": "b"
+                                }
+                            },
+                            {
+                                "user": {
+                                    "title": "bar",
+                                    "name": "c"
+                                }
+                            }
+                        ]
+                    },
+                    "partials": {},
+                    "error": false,
+                    "strict": false
+                },
+                {
+                    "name": "dotted property, string match",
+                    "template": "{% assign x = a | compact: 'user.title' %}{% for obj in x %}{% for i in obj %}({{ i[0] }},{{ i[1] }}){% endfor %}{% endfor %}",
+                    "want": "(user.title,foo)(name,a)(user.title,bar)(name,c)",
+                    "context": {
+                        "a": [
+                            {
+                                "user.title": "foo",
+                                "name": "a"
+                            },
+                            {
+                                "user.title": null,
+                                "name": "b"
+                            },
+                            {
+                                "user.title": "bar",
+                                "name": "c"
+                            }
                         ]
                     },
                     "partials": {},
@@ -1276,6 +1306,30 @@
                     "template": "{{ nosuchthing | compact }}",
                     "want": "",
                     "context": {},
+                    "partials": {},
+                    "error": false,
+                    "strict": false
+                },
+                {
+                    "name": "property, array of objects",
+                    "template": "{% assign x = a | compact: 'title' %}{% for obj in x %}{% for i in obj %}({{ i[0] }},{{ i[1] }}){% endfor %}{% endfor %}",
+                    "want": "(title,foo)(name,a)(title,bar)(name,c)",
+                    "context": {
+                        "a": [
+                            {
+                                "title": "foo",
+                                "name": "a"
+                            },
+                            {
+                                "title": null,
+                                "name": "b"
+                            },
+                            {
+                                "title": "bar",
+                                "name": "c"
+                            }
+                        ]
+                    },
                     "partials": {},
                     "error": false,
                     "strict": false
@@ -5390,6 +5444,127 @@
                     "strict": false
                 },
                 {
+                    "name": "dotted property, path and string match",
+                    "template": "{{ a | map: 'user.title' | join: '#' }}",
+                    "want": "foo#bar#baz",
+                    "context": {
+                        "a": [
+                            {
+                                "user.title": "foo"
+                            },
+                            {
+                                "user": {
+                                    "title": "bar"
+                                }
+                            },
+                            {
+                                "user": {
+                                    "title": "baz"
+                                }
+                            }
+                        ]
+                    },
+                    "partials": {},
+                    "error": false,
+                    "strict": false
+                },
+                {
+                    "name": "dotted property, path match",
+                    "template": "{{ a | map: 'user.title' | join: '#' }}",
+                    "want": "foo#bar#baz",
+                    "context": {
+                        "a": [
+                            {
+                                "user": {
+                                    "title": "foo"
+                                }
+                            },
+                            {
+                                "user": {
+                                    "title": "bar"
+                                }
+                            },
+                            {
+                                "user": {
+                                    "title": "baz"
+                                }
+                            }
+                        ]
+                    },
+                    "partials": {},
+                    "error": false,
+                    "strict": false
+                },
+                {
+                    "name": "dotted property, path match, missing property",
+                    "template": "{{ a | map: 'user.title' | join: '#' }}",
+                    "want": "foo##baz",
+                    "context": {
+                        "a": [
+                            {
+                                "user": {
+                                    "title": "foo"
+                                }
+                            },
+                            {
+                                "user": {
+                                    "firstname": "bar"
+                                }
+                            },
+                            {
+                                "user": {
+                                    "title": "baz"
+                                }
+                            }
+                        ]
+                    },
+                    "partials": {},
+                    "error": false,
+                    "strict": false
+                },
+                {
+                    "name": "dotted property, string match",
+                    "template": "{{ a | map: 'user.title' | join: '#' }}",
+                    "want": "foo#bar#baz",
+                    "context": {
+                        "a": [
+                            {
+                                "user.title": "foo"
+                            },
+                            {
+                                "user.title": "bar"
+                            },
+                            {
+                                "user.title": "baz"
+                            }
+                        ]
+                    },
+                    "partials": {},
+                    "error": false,
+                    "strict": false
+                },
+                {
+                    "name": "dotted property, string match, missing property",
+                    "template": "{{ a | map: 'user.title' | join: '#' }}",
+                    "want": "foo##baz",
+                    "context": {
+                        "a": [
+                            {
+                                "user.title": "foo"
+                            },
+                            {
+                                "user.firstname": "bar"
+                            },
+                            {
+                                "user.title": "baz"
+                            }
+                        ]
+                    },
+                    "partials": {},
+                    "error": false,
+                    "strict": false
+                },
+                {
                     "name": "input is a hash",
                     "template": "{{ a | map: 'title' | join: '#' }}",
                     "want": "foo",
@@ -5452,6 +5627,39 @@
                                     "title": "baz"
                                 }
                             ]
+                        ]
+                    },
+                    "partials": {},
+                    "error": false,
+                    "strict": false
+                },
+                {
+                    "name": "property with bracketed index",
+                    "template": "{{ a | map: 'user[1]' | join: '#' }}",
+                    "want": "##",
+                    "context": {
+                        "a": [
+                            {
+                                "user": [
+                                    1,
+                                    2,
+                                    3
+                                ]
+                            },
+                            {
+                                "user": [
+                                    4,
+                                    5,
+                                    6
+                                ]
+                            },
+                            {
+                                "user": [
+                                    7,
+                                    8,
+                                    9
+                                ]
+                            }
                         ]
                     },
                     "partials": {},
@@ -9004,6 +9212,54 @@
                     "strict": false
                 },
                 {
+                    "name": "hashes with dotted property argument, path match",
+                    "template": "{{ a | sum: 'k.foo' }}",
+                    "want": "6",
+                    "context": {
+                        "a": [
+                            {
+                                "k": {
+                                    "foo": 1
+                                }
+                            },
+                            {
+                                "k": {
+                                    "foo": 2
+                                }
+                            },
+                            {
+                                "k": {
+                                    "foo": 3
+                                }
+                            }
+                        ]
+                    },
+                    "partials": {},
+                    "error": false,
+                    "strict": false
+                },
+                {
+                    "name": "hashes with dotted property argument, string match",
+                    "template": "{{ a | sum: 'k.foo' }}",
+                    "want": "6",
+                    "context": {
+                        "a": [
+                            {
+                                "k.foo": 1
+                            },
+                            {
+                                "k.foo": 2
+                            },
+                            {
+                                "k.foo": 3
+                            }
+                        ]
+                    },
+                    "partials": {},
+                    "error": false,
+                    "strict": false
+                },
+                {
                     "name": "hashes with numeric strings and property argument",
                     "template": "{{ a | sum: 'k' }}",
                     "want": "6",
@@ -9873,7 +10129,7 @@
                             {
                                 "foo": [
                                     3,
-                                    9,
+                                    4,
                                     5
                                 ]
                             },
@@ -9944,7 +10200,7 @@
                     "strict": false
                 },
                 {
-                    "name": "property, uniq arrays is a no op",
+                    "name": "property, arrays",
                     "template": "{% assign x = a | uniq: 'foo' -%}\n{% for item in x -%}\n{% for pair in item -%}\n({{ pair[0] }}, {{ pair[1] | join: '#' }})\n{% endfor -%}\n{% endfor %}",
                     "want": "(foo, 3#4#5)\n(foo, 3#2#5)\n(foo, 3#-1#5)\n",
                     "context": {
@@ -10309,6 +10565,54 @@
                             },
                             {
                                 "title": null
+                            }
+                        ]
+                    },
+                    "partials": {},
+                    "error": false,
+                    "strict": false
+                },
+                {
+                    "name": "array of hashes with dotted property, path match",
+                    "template": "{% assign x = a | where: 'user.title', 'bar' %}{% for obj in x %}{% for i in obj %}({{ i[0] }},{{ i[1].title }}){% endfor %}{% endfor %}",
+                    "want": "(user,bar)",
+                    "context": {
+                        "a": [
+                            {
+                                "user": {
+                                    "title": "foo"
+                                }
+                            },
+                            {
+                                "user": {
+                                    "title": "bar"
+                                }
+                            },
+                            {
+                                "user": {
+                                    "title": null
+                                }
+                            }
+                        ]
+                    },
+                    "partials": {},
+                    "error": false,
+                    "strict": false
+                },
+                {
+                    "name": "array of hashes with dotted property, string match",
+                    "template": "{% assign x = a | where: 'user.title', 'bar' %}{% for obj in x %}{% for i in obj %}({{ i[0] }},{{ i[1] }}){% endfor %}{% endfor %}",
+                    "want": "(user.title,bar)",
+                    "context": {
+                        "a": [
+                            {
+                                "user.title": "foo"
+                            },
+                            {
+                                "user.title": "bar"
+                            },
+                            {
+                                "user.title": null
                             }
                         ]
                     },

--- a/golden_liquid.json
+++ b/golden_liquid.json
@@ -1,5 +1,5 @@
 {
-    "version": "0.23.0",
+    "version": "0.24.0",
     "test_groups": [
         {
             "name": "liquid.golden.abs_filter",
@@ -7926,6 +7926,179 @@
                     "template": "{{ nosuchthing | sort | join: '#' }}",
                     "want": "",
                     "context": {},
+                    "partials": {},
+                    "error": false,
+                    "strict": false
+                },
+                {
+                    "name": "property with a bracketed index, silently does not sort",
+                    "template": "{% assign sorted = a | sort: 'foo[1]' -%}\n{% for item in sorted -%}\n{% for pair in item -%}\n({{ pair[0] }}, {{ pair[1] | join: '#' }})\n{% endfor -%}\n{% endfor %}",
+                    "want": "(foo, 3#4#5)\n(foo, 3#2#5)\n(foo, 3#9#5)\n(foo, 3#-1#5)\n",
+                    "context": {
+                        "a": [
+                            {
+                                "foo": [
+                                    3,
+                                    4,
+                                    5
+                                ]
+                            },
+                            {
+                                "foo": [
+                                    3,
+                                    2,
+                                    5
+                                ]
+                            },
+                            {
+                                "foo": [
+                                    3,
+                                    9,
+                                    5
+                                ]
+                            },
+                            {
+                                "foo": [
+                                    3,
+                                    -1,
+                                    5
+                                ]
+                            }
+                        ]
+                    },
+                    "partials": {},
+                    "error": false,
+                    "strict": false
+                },
+                {
+                    "name": "property with a dot, path match",
+                    "template": "{% assign sorted = a | sort: 'foo.bar' -%}\n{% for item in sorted -%}\n{% for pair in item.foo -%}\n({{ pair[0] }}, {{ pair[1] }})\n{% endfor -%}\n{% endfor %}",
+                    "want": "(bar, -1)\n(bar, 2)\n(bar, 4)\n(bar, 9)\n",
+                    "context": {
+                        "a": [
+                            {
+                                "foo": {
+                                    "bar": 4
+                                }
+                            },
+                            {
+                                "foo": {
+                                    "bar": 2
+                                }
+                            },
+                            {
+                                "foo": {
+                                    "bar": 9
+                                }
+                            },
+                            {
+                                "foo": {
+                                    "bar": -1
+                                }
+                            }
+                        ]
+                    },
+                    "partials": {},
+                    "error": false,
+                    "strict": false
+                },
+                {
+                    "name": "property with a dot, string and path match",
+                    "template": "{% assign sorted = a | sort: 'foo.bar' -%}\n{% for item in sorted -%}\n{% for pair in item -%}\n({{ pair[0] }}, \n{%- if pair[1].bar -%}\n{{ pair[1].bar }}{%else%}{{ pair[1] -}}\n{% endif %})\n{% endfor -%}\n{% endfor %}",
+                    "want": "(foo,-1)\n(foo,2)\n(foo.bar,4)\n(foo,9)\n",
+                    "context": {
+                        "a": [
+                            {
+                                "foo.bar": 4
+                            },
+                            {
+                                "foo": {
+                                    "bar": 2
+                                }
+                            },
+                            {
+                                "foo": {
+                                    "bar": 9
+                                }
+                            },
+                            {
+                                "foo": {
+                                    "bar": -1
+                                }
+                            }
+                        ]
+                    },
+                    "partials": {},
+                    "error": false,
+                    "strict": false
+                },
+                {
+                    "name": "property with a dot, string match",
+                    "template": "{% assign sorted = a | sort: 'foo.bar' -%}\n{% for item in sorted -%}\n{% for pair in item -%}\n({{ pair[0] }}, {{ pair[1] }})\n{% endfor -%}\n{% endfor %}",
+                    "want": "(foo.bar, -1)\n(foo.bar, 2)\n(foo.bar, 4)\n(foo.bar, 9)\n",
+                    "context": {
+                        "a": [
+                            {
+                                "foo.bar": 4
+                            },
+                            {
+                                "foo.bar": 2
+                            },
+                            {
+                                "foo.bar": 9
+                            },
+                            {
+                                "foo.bar": -1
+                            }
+                        ]
+                    },
+                    "partials": {},
+                    "error": false,
+                    "strict": false
+                },
+                {
+                    "name": "property, array contains array",
+                    "template": "{% assign sorted = a | sort: 'foo' -%}\n{% for item in sorted -%}\n{% for pair in item -%}\n({{ pair[0] }}, {{ pair[1] }})\n{% endfor -%}\n{% endfor %}",
+                    "want": "",
+                    "context": {
+                        "a": [
+                            {
+                                "foo": 4
+                            },
+                            {
+                                "foo": 2
+                            },
+                            {
+                                "foo": 9
+                            },
+                            [
+                                42,
+                                7
+                            ]
+                        ]
+                    },
+                    "partials": {},
+                    "error": false,
+                    "strict": false
+                },
+                {
+                    "name": "property, array contains primitive",
+                    "template": "{% assign sorted = a | sort: 'foo' -%}\n{% for item in sorted -%}\n{% for pair in item -%}\n({{ pair[0] }}, {{ pair[1] }})\n{% endfor -%}\n{% endfor %}",
+                    "want": "",
+                    "context": {
+                        "a": [
+                            {
+                                "foo": 4
+                            },
+                            {
+                                "foo": 2
+                            },
+                            {
+                                "foo": 9
+                            },
+                            false
+                        ]
+                    },
                     "partials": {},
                     "error": false,
                     "strict": false

--- a/golden_liquid.yaml
+++ b/golden_liquid.yaml
@@ -915,21 +915,6 @@ test_groups:
     strict: false
 - name: liquid.golden.compact_filter
   tests:
-  - name: array of objects with key property
-    template: '{% assign x = a | compact: ''title'' %}{% for obj in x %}{% for i in
-      obj %}({{ i[0] }},{{ i[1] }}){% endfor %}{% endfor %}'
-    want: (title,foo)(name,a)(title,bar)(name,c)
-    context:
-      a:
-      - title: foo
-        name: a
-      - title: null
-        name: b
-      - title: bar
-        name: c
-    partials: {}
-    error: false
-    strict: false
   - name: array with a nil
     template: '{{ a | compact | join: ''#'' }}'
     want: b#a#A
@@ -939,6 +924,40 @@ test_groups:
       - a
       - null
       - A
+    partials: {}
+    error: false
+    strict: false
+  - name: dotted property, path match
+    template: '{% assign x = a | compact: ''user.title'' %}{% for obj in x %}{% for
+      i in obj %}({{ i[0] }},{{ i[1].title }},{{ i[1].name }}){% endfor %}{% endfor
+      %}'
+    want: (user,foo,a)(user,bar,c)
+    context:
+      a:
+      - user:
+          title: foo
+          name: a
+      - user:
+          title: null
+          name: b
+      - user:
+          title: bar
+          name: c
+    partials: {}
+    error: false
+    strict: false
+  - name: dotted property, string match
+    template: '{% assign x = a | compact: ''user.title'' %}{% for obj in x %}{% for
+      i in obj %}({{ i[0] }},{{ i[1] }}){% endfor %}{% endfor %}'
+    want: (user.title,foo)(name,a)(user.title,bar)(name,c)
+    context:
+      a:
+      - user.title: foo
+        name: a
+      - user.title: null
+        name: b
+      - user.title: bar
+        name: c
     partials: {}
     error: false
     strict: false
@@ -962,6 +981,21 @@ test_groups:
     template: '{{ nosuchthing | compact }}'
     want: ''
     context: {}
+    partials: {}
+    error: false
+    strict: false
+  - name: property, array of objects
+    template: '{% assign x = a | compact: ''title'' %}{% for obj in x %}{% for i in
+      obj %}({{ i[0] }},{{ i[1] }}){% endfor %}{% endfor %}'
+    want: (title,foo)(name,a)(title,bar)(name,c)
+    context:
+      a:
+      - title: foo
+        name: a
+      - title: null
+        name: b
+      - title: bar
+        name: c
     partials: {}
     error: false
     strict: false
@@ -4082,6 +4116,69 @@ test_groups:
     partials: {}
     error: false
     strict: false
+  - name: dotted property, path and string match
+    template: '{{ a | map: ''user.title'' | join: ''#'' }}'
+    want: foo#bar#baz
+    context:
+      a:
+      - user.title: foo
+      - user:
+          title: bar
+      - user:
+          title: baz
+    partials: {}
+    error: false
+    strict: false
+  - name: dotted property, path match
+    template: '{{ a | map: ''user.title'' | join: ''#'' }}'
+    want: foo#bar#baz
+    context:
+      a:
+      - user:
+          title: foo
+      - user:
+          title: bar
+      - user:
+          title: baz
+    partials: {}
+    error: false
+    strict: false
+  - name: dotted property, path match, missing property
+    template: '{{ a | map: ''user.title'' | join: ''#'' }}'
+    want: foo##baz
+    context:
+      a:
+      - user:
+          title: foo
+      - user:
+          firstname: bar
+      - user:
+          title: baz
+    partials: {}
+    error: false
+    strict: false
+  - name: dotted property, string match
+    template: '{{ a | map: ''user.title'' | join: ''#'' }}'
+    want: foo#bar#baz
+    context:
+      a:
+      - user.title: foo
+      - user.title: bar
+      - user.title: baz
+    partials: {}
+    error: false
+    strict: false
+  - name: dotted property, string match, missing property
+    template: '{{ a | map: ''user.title'' | join: ''#'' }}'
+    want: foo##baz
+    context:
+      a:
+      - user.title: foo
+      - user.firstname: bar
+      - user.title: baz
+    partials: {}
+    error: false
+    strict: false
   - name: input is a hash
     template: '{{ a | map: ''title'' | join: ''#'' }}'
     want: foo
@@ -4119,6 +4216,26 @@ test_groups:
       - title: foo
       - - title: bar
         - title: baz
+    partials: {}
+    error: false
+    strict: false
+  - name: property with bracketed index
+    template: '{{ a | map: ''user[1]'' | join: ''#'' }}'
+    want: '##'
+    context:
+      a:
+      - user:
+        - 1
+        - 2
+        - 3
+      - user:
+        - 4
+        - 5
+        - 6
+      - user:
+        - 7
+        - 8
+        - 9
     partials: {}
     error: false
     strict: false
@@ -6345,7 +6462,7 @@ test_groups:
 
       (foo.bar, B)
 
-      (foo.bar, c)
+      (foo.bar, C)
 
       '
     context:
@@ -6820,6 +6937,31 @@ test_groups:
     want: '0'
     context:
       a: []
+    partials: {}
+    error: false
+    strict: false
+  - name: hashes with dotted property argument, path match
+    template: '{{ a | sum: ''k.foo'' }}'
+    want: '6'
+    context:
+      a:
+      - k:
+          foo: 1
+      - k:
+          foo: 2
+      - k:
+          foo: 3
+    partials: {}
+    error: false
+    strict: false
+  - name: hashes with dotted property argument, string match
+    template: '{{ a | sum: ''k.foo'' }}'
+    want: '6'
+    context:
+      a:
+      - k.foo: 1
+      - k.foo: 2
+      - k.foo: 3
     partials: {}
     error: false
     strict: false
@@ -7594,6 +7736,130 @@ test_groups:
     partials: {}
     error: false
     strict: false
+  - name: property with a dot, string match
+    template: '{% assign x = a | uniq: ''user.title'' %}{% for obj in x %}{% for i
+      in obj %}({{ i[0] }},{{ i[1] }}){% endfor %}{% endfor %}'
+    want: (user.title,foo)(name,a)(user.title,bar)(name,c)
+    context:
+      a:
+      - user.title: foo
+        name: a
+      - user.title: foo
+        name: b
+      - user.title: bar
+        name: c
+    partials: {}
+    error: false
+    strict: false
+  - name: property with bracketed index
+    template: '{% assign x = a | uniq: ''foo[1]'' -%}
+
+      {% for item in x -%}
+
+      {% for pair in item -%}
+
+      ({{ pair[0] }}, {{ pair[1] | join: ''#'' }})
+
+      {% endfor -%}
+
+      {% endfor %}'
+    want: '(foo, 3#4#5)
+
+      '
+    context:
+      a:
+      - foo:
+        - 3
+        - 4
+        - 5
+      - foo:
+        - 3
+        - 2
+        - 5
+      - foo:
+        - 3
+        - 4
+        - 5
+      - foo:
+        - 3
+        - -1
+        - 5
+    partials: {}
+    error: false
+    strict: false
+  - name: property, array contains a primitive
+    template: '{% assign x = a | uniq: ''title'' %}{% for obj in x %}{% for i in obj
+      %}({{ i[0] }},{{ i[1] }}){% endfor %}{% endfor %}'
+    want: ''
+    context:
+      a:
+      - title: foo
+        name: a
+      - title: foo
+        name: b
+      - title: bar
+        name: c
+      - false
+    partials: {}
+    error: false
+    strict: false
+  - name: property, array contains an array
+    template: '{% assign x = a | uniq: ''title'' %}{% for obj in x %}{% for i in obj
+      %}({{ i[0] }},{{ i[1] }}){% endfor %}{% endfor %}'
+    want: (title,foo)(name,a)(title,bar)(name,c)(,)
+    context:
+      a:
+      - title: foo
+        name: a
+      - title: foo
+        name: b
+      - title: bar
+        name: c
+      - - foo
+        - bar
+    partials: {}
+    error: false
+    strict: false
+  - name: property, arrays
+    template: '{% assign x = a | uniq: ''foo'' -%}
+
+      {% for item in x -%}
+
+      {% for pair in item -%}
+
+      ({{ pair[0] }}, {{ pair[1] | join: ''#'' }})
+
+      {% endfor -%}
+
+      {% endfor %}'
+    want: '(foo, 3#4#5)
+
+      (foo, 3#2#5)
+
+      (foo, 3#-1#5)
+
+      '
+    context:
+      a:
+      - foo:
+        - 3
+        - 4
+        - 5
+      - foo:
+        - 3
+        - 2
+        - 5
+      - foo:
+        - 3
+        - 4
+        - 5
+      - foo:
+        - 3
+        - -1
+        - 5
+    partials: {}
+    error: false
+    strict: false
   - name: too many arguments
     template: '{{ nosuchthing | uniq: ''foo'', ''bar'' }}'
     want: ''
@@ -7834,6 +8100,33 @@ test_groups:
       - heading: foo
       - title: bar
       - title: null
+    partials: {}
+    error: false
+    strict: false
+  - name: array of hashes with dotted property, path match
+    template: '{% assign x = a | where: ''user.title'', ''bar'' %}{% for obj in x
+      %}{% for i in obj %}({{ i[0] }},{{ i[1].title }}){% endfor %}{% endfor %}'
+    want: (user,bar)
+    context:
+      a:
+      - user:
+          title: foo
+      - user:
+          title: bar
+      - user:
+          title: null
+    partials: {}
+    error: false
+    strict: false
+  - name: array of hashes with dotted property, string match
+    template: '{% assign x = a | where: ''user.title'', ''bar'' %}{% for obj in x
+      %}{% for i in obj %}({{ i[0] }},{{ i[1] }}){% endfor %}{% endfor %}'
+    want: (user.title,bar)
+    context:
+      a:
+      - user.title: foo
+      - user.title: bar
+      - user.title: null
     partials: {}
     error: false
     strict: false

--- a/golden_liquid.yaml
+++ b/golden_liquid.yaml
@@ -6257,6 +6257,156 @@ test_groups:
     partials: {}
     error: false
     strict: false
+  - name: property with a dot, path match
+    template: '{% assign sorted = a | sort_natural: ''foo.bar'' -%}
+
+      {% for item in sorted -%}
+
+      {% for pair in item.foo -%}
+
+      ({{ pair[0] }}, {{ pair[1] }})
+
+      {% endfor -%}
+
+      {% endfor %}'
+    want: '(bar, a)
+
+      (bar, A)
+
+      (bar, b)
+
+      (bar, B)
+
+      (bar, C)
+
+      '
+    context:
+      a:
+      - foo:
+          bar: b
+      - foo:
+          bar: a
+      - foo:
+          bar: C
+      - foo:
+          bar: B
+      - foo:
+          bar: A
+    partials: {}
+    error: false
+    strict: false
+  - name: property with a dot, string and path match
+    template: "{% assign sorted = a | sort_natural: 'foo.bar' -%}\n{% for item in\
+      \ sorted -%}\n{% for pair in item -%}\n({{ pair[0] }}, \n{%- if pair[1].bar\
+      \ -%}\n{{ pair[1].bar }}{%else%}{{ pair[1] -}}\n{% endif %})\n{% endfor -%}\n\
+      {% endfor %}"
+    want: '(foo,a)
+
+      (foo,A)
+
+      (foo.bar,b)
+
+      (foo,B)
+
+      (foo,C)
+
+      '
+    context:
+      a:
+      - foo.bar: b
+      - foo:
+          bar: a
+      - foo:
+          bar: C
+      - foo:
+          bar: B
+      - foo:
+          bar: A
+    partials: {}
+    error: false
+    strict: false
+  - name: property with a dot, string match
+    template: '{% assign sorted = a | sort_natural: ''foo.bar'' -%}
+
+      {% for item in sorted -%}
+
+      {% for pair in item -%}
+
+      ({{ pair[0] }}, {{ pair[1] }})
+
+      {% endfor -%}
+
+      {% endfor %}'
+    want: '(foo.bar, a)
+
+      (foo.bar, A)
+
+      (foo.bar, b)
+
+      (foo.bar, B)
+
+      (foo.bar, c)
+
+      '
+    context:
+      a:
+      - foo.bar: b
+      - foo.bar: a
+      - foo.bar: C
+      - foo.bar: B
+      - foo.bar: A
+    partials: {}
+    error: false
+    strict: false
+  - name: property, array contains array
+    template: '{% assign sorted = a | sort_natural: ''foo'' -%}
+
+      {% for item in sorted -%}
+
+      {% for pair in item -%}
+
+      ({{ pair[0] }}, {{ pair[1] }})
+
+      {% endfor -%}
+
+      {% endfor %}'
+    want: ''
+    context:
+      a:
+      - foo: b
+      - foo: a
+      - foo: C
+      - foo: B
+      - foo: A
+      - - 42
+        - 7
+    partials: {}
+    error: false
+    strict: false
+  - name: property, array contains primitive
+    template: '{% assign sorted = a | sort_natural: ''foo'' -%}
+
+      {% for item in sorted -%}
+
+      {% for pair in item -%}
+
+      ({{ pair[0] }}, {{ pair[1] }})
+
+      {% endfor -%}
+
+      {% endfor %}'
+    want: ''
+    context:
+      a:
+      - foo: b
+      - foo: a
+      - foo: C
+      - foo: B
+      - foo: A
+      - false
+    partials: {}
+    error: false
+    strict: false
 - name: liquid.golden.special
   tests:
   - name: first of a string

--- a/golden_liquid.yaml
+++ b/golden_liquid.yaml
@@ -1,4 +1,4 @@
-version: 0.23.0
+version: 0.24.0
 test_groups:
 - name: liquid.golden.abs_filter
   tests:
@@ -5948,6 +5948,182 @@ test_groups:
     template: '{{ nosuchthing | sort | join: ''#'' }}'
     want: ''
     context: {}
+    partials: {}
+    error: false
+    strict: false
+  - name: property with a bracketed index, silently does not sort
+    template: '{% assign sorted = a | sort: ''foo[1]'' -%}
+
+      {% for item in sorted -%}
+
+      {% for pair in item -%}
+
+      ({{ pair[0] }}, {{ pair[1] | join: ''#'' }})
+
+      {% endfor -%}
+
+      {% endfor %}'
+    want: '(foo, 3#4#5)
+
+      (foo, 3#2#5)
+
+      (foo, 3#9#5)
+
+      (foo, 3#-1#5)
+
+      '
+    context:
+      a:
+      - foo:
+        - 3
+        - 4
+        - 5
+      - foo:
+        - 3
+        - 2
+        - 5
+      - foo:
+        - 3
+        - 9
+        - 5
+      - foo:
+        - 3
+        - -1
+        - 5
+    partials: {}
+    error: false
+    strict: false
+  - name: property with a dot, path match
+    template: '{% assign sorted = a | sort: ''foo.bar'' -%}
+
+      {% for item in sorted -%}
+
+      {% for pair in item.foo -%}
+
+      ({{ pair[0] }}, {{ pair[1] }})
+
+      {% endfor -%}
+
+      {% endfor %}'
+    want: '(bar, -1)
+
+      (bar, 2)
+
+      (bar, 4)
+
+      (bar, 9)
+
+      '
+    context:
+      a:
+      - foo:
+          bar: 4
+      - foo:
+          bar: 2
+      - foo:
+          bar: 9
+      - foo:
+          bar: -1
+    partials: {}
+    error: false
+    strict: false
+  - name: property with a dot, string and path match
+    template: "{% assign sorted = a | sort: 'foo.bar' -%}\n{% for item in sorted -%}\n\
+      {% for pair in item -%}\n({{ pair[0] }}, \n{%- if pair[1].bar -%}\n{{ pair[1].bar\
+      \ }}{%else%}{{ pair[1] -}}\n{% endif %})\n{% endfor -%}\n{% endfor %}"
+    want: '(foo,-1)
+
+      (foo,2)
+
+      (foo.bar,4)
+
+      (foo,9)
+
+      '
+    context:
+      a:
+      - foo.bar: 4
+      - foo:
+          bar: 2
+      - foo:
+          bar: 9
+      - foo:
+          bar: -1
+    partials: {}
+    error: false
+    strict: false
+  - name: property with a dot, string match
+    template: '{% assign sorted = a | sort: ''foo.bar'' -%}
+
+      {% for item in sorted -%}
+
+      {% for pair in item -%}
+
+      ({{ pair[0] }}, {{ pair[1] }})
+
+      {% endfor -%}
+
+      {% endfor %}'
+    want: '(foo.bar, -1)
+
+      (foo.bar, 2)
+
+      (foo.bar, 4)
+
+      (foo.bar, 9)
+
+      '
+    context:
+      a:
+      - foo.bar: 4
+      - foo.bar: 2
+      - foo.bar: 9
+      - foo.bar: -1
+    partials: {}
+    error: false
+    strict: false
+  - name: property, array contains array
+    template: '{% assign sorted = a | sort: ''foo'' -%}
+
+      {% for item in sorted -%}
+
+      {% for pair in item -%}
+
+      ({{ pair[0] }}, {{ pair[1] }})
+
+      {% endfor -%}
+
+      {% endfor %}'
+    want: ''
+    context:
+      a:
+      - foo: 4
+      - foo: 2
+      - foo: 9
+      - - 42
+        - 7
+    partials: {}
+    error: false
+    strict: false
+  - name: property, array contains primitive
+    template: '{% assign sorted = a | sort: ''foo'' -%}
+
+      {% for item in sorted -%}
+
+      {% for pair in item -%}
+
+      ({{ pair[0] }}, {{ pair[1] }})
+
+      {% endfor -%}
+
+      {% endfor %}'
+    want: ''
+    context:
+      a:
+      - foo: 4
+      - foo: 2
+      - foo: 9
+      - false
     partials: {}
     error: false
     strict: false

--- a/shopify_liquid/Gemfile.lock
+++ b/shopify_liquid/Gemfile.lock
@@ -1,9 +1,9 @@
 GIT
   remote: git@github.com:Shopify/liquid.git
-  revision: 323951b36fb6a4f1b7e4394cd5746cd78b49791b
+  revision: ecf25ea83d53b51c66f12ad8cf3e855dab6f4e4d
   branch: main
   specs:
-    liquid (5.6.1)
+    liquid (5.6.4)
       bigdecimal
       strscan (>= 3.1.1)
 
@@ -37,7 +37,7 @@ GEM
       parser (>= 3.3.1.0)
     ruby-progressbar (1.13.0)
     strscan (3.1.2)
-    unicode-display_width (3.1.3)
+    unicode-display_width (3.1.4)
       unicode-emoji (~> 4.0, >= 4.0.4)
     unicode-emoji (4.0.4)
 


### PR DESCRIPTION
Add tests for filters added in Shopify/Liquid 5.7.0. See [Shopify/liquid #1869](https://github.com/Shopify/liquid/pull/1869).

New filters:
- [ ] reject
- [ ] has
- [ ] find
- [ ] find_index

Existing filters that now support dotted property arguments:
- [x] sort
- [x] sort_natural
- [x] uniq
- [x] map
- [x] compact
- [x] sum
- [x] where

