### PR TITLE
Add test for logical `not` operator

### DIFF
--- a/golden_liquid.json
+++ b/golden_liquid.json
@@ -7054,14 +7054,6 @@
       "invalid": true
     },
     {
-      "name": "tags, if, not is not a valid operator",
-      "template": "{% if not false %}TRUE{% else %}FALSE{% endif %}",
-      "tags": [
-        "absent"
-      ],
-      "invalid": true
-    },
-    {
       "name": "tags, ifchanged, changed from initial state",
       "template": "{% ifchanged %}hello{% endifchanged %}",
       "result": "hello"

--- a/golden_liquid.json
+++ b/golden_liquid.json
@@ -7054,6 +7054,14 @@
       "invalid": true
     },
     {
+      "name": "tags, if, not is not a valid operator",
+      "template": "{% if not false %}TRUE{% else %}FALSE{% endif %}",
+      "tags": [
+        "absent"
+      ],
+      "invalid": true
+    },
+    {
       "name": "tags, ifchanged, changed from initial state",
       "template": "{% ifchanged %}hello{% endifchanged %}",
       "result": "hello"

--- a/tests/tags/if.json
+++ b/tests/tags/if.json
@@ -498,6 +498,14 @@
         "absent"
       ],
       "invalid": true
+    },
+    {
+      "name": "not is not a valid operator",
+      "template": "{% if not false %}TRUE{% else %}FALSE{% endif %}",
+      "tags": [
+        "absent"
+      ],
+      "invalid": true
     }
   ]
 }


### PR DESCRIPTION
Test that the `not` operator is not supported in `{% if %}` tag expressions.