### PR TITLE
Update Shopify/liquid and the `map` filter

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,20 +1,20 @@
 GIT
   remote: https://github.com/Shopify/liquid.git
-  revision: aa1640035f172bcbd064959d8e7d00aac07243d7
+  revision: 2b75bfaff412c23c9b9434a11eafcef869d89c17
   branch: main
   specs:
-    liquid (5.8.2)
+    liquid (5.8.3)
       bigdecimal
       strscan (>= 3.1.1)
 
 GEM
   remote: https://rubygems.org/
   specs:
-    ast (2.4.2)
+    ast (2.4.3)
     base64 (0.2.0)
     bigdecimal (3.1.9)
     hana (1.3.7)
-    json (2.10.1)
+    json (2.10.2)
     json_schemer (2.4.0)
       bigdecimal
       hana (~> 1.3)
@@ -23,16 +23,17 @@ GEM
     language_server-protocol (3.17.0.4)
     lint_roller (1.1.0)
     lru_redux (1.1.0)
-    minitest (5.25.4)
+    minitest (5.25.5)
     parallel (1.26.3)
-    parser (3.3.7.1)
+    parser (3.3.7.4)
       ast (~> 2.4.1)
       racc
+    prism (1.4.0)
     racc (1.8.1)
     rainbow (3.1.1)
     rake (13.2.1)
     regexp_parser (2.10.0)
-    rubocop (1.73.2)
+    rubocop (1.75.2)
       json (~> 2.3)
       language_server-protocol (~> 3.17.0.2)
       lint_roller (~> 1.1.0)
@@ -40,11 +41,12 @@ GEM
       parser (>= 3.3.0.2)
       rainbow (>= 2.2.2, < 4.0)
       regexp_parser (>= 2.9.3, < 3.0)
-      rubocop-ast (>= 1.38.0, < 2.0)
+      rubocop-ast (>= 1.44.0, < 2.0)
       ruby-progressbar (~> 1.7)
       unicode-display_width (>= 2.4.0, < 4.0)
-    rubocop-ast (1.38.1)
-      parser (>= 3.3.1.0)
+    rubocop-ast (1.44.0)
+      parser (>= 3.3.7.2)
+      prism (~> 1.4)
     rubocop-minitest (0.37.1)
       lint_roller (~> 1.1)
       rubocop (>= 1.72.1, < 2.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,9 +1,9 @@
 GIT
   remote: https://github.com/Shopify/liquid.git
-  revision: 2b75bfaff412c23c9b9434a11eafcef869d89c17
+  revision: dbe709c3bf2f8521764ae51b36dd551905dfad7e
   branch: main
   specs:
-    liquid (5.8.3)
+    liquid (5.8.4)
       bigdecimal
       strscan (>= 3.1.1)
 
@@ -44,7 +44,7 @@ GEM
       rubocop-ast (>= 1.44.0, < 2.0)
       ruby-progressbar (~> 1.7)
       unicode-display_width (>= 2.4.0, < 4.0)
-    rubocop-ast (1.44.0)
+    rubocop-ast (1.44.1)
       parser (>= 3.3.7.2)
       prism (~> 1.4)
     rubocop-minitest (0.37.1)
@@ -56,7 +56,7 @@ GEM
       rubocop (>= 1.72.1)
     ruby-progressbar (1.13.0)
     simpleidn (0.2.3)
-    strscan (3.1.2)
+    strscan (3.1.3)
     unicode-display_width (3.1.4)
       unicode-emoji (~> 4.0, >= 4.0.4)
     unicode-emoji (4.0.4)

--- a/golden_liquid.json
+++ b/golden_liquid.json
@@ -2967,7 +2967,7 @@
     },
     {
       "name": "filters, map, undefined argument",
-      "template": "{{ a | map: nosuchthing | join: '#' }}",
+      "template": "{% assign b = a | map: nosuchthing %}{% for x in b %}{% for y in x %}{{ y[0] }}:{{ y[1] }},{% endfor %}{% endfor %}",
       "data": {
         "a": [
           {
@@ -2978,7 +2978,22 @@
           }
         ]
       },
-      "result": "#"
+      "result": "title:foo,title:bar,"
+    },
+    {
+      "name": "filters, map, argument is explicit nil",
+      "template": "{% assign b = a | map: nil %}{% for x in b %}{% for y in x %}{{ y[0] }}:{{ y[1] }},{% endfor %}{% endfor %}",
+      "data": {
+        "a": [
+          {
+            "title": "foo"
+          },
+          {
+            "title": "bar"
+          }
+        ]
+      },
+      "result": "title:foo,title:bar,"
     },
     {
       "name": "filters, map, nested arrays get flattened",

--- a/tests/filters/map.json
+++ b/tests/filters/map.json
@@ -63,7 +63,7 @@
     },
     {
       "name": "undefined argument",
-      "template": "{{ a | map: nosuchthing | join: '#' }}",
+      "template": "{% assign b = a | map: nosuchthing %}{% for x in b %}{% for y in x %}{{ y[0] }}:{{ y[1] }},{% endfor %}{% endfor %}",
       "data": {
         "a": [
           {
@@ -74,7 +74,22 @@
           }
         ]
       },
-      "result": "#"
+      "result": "title:foo,title:bar,"
+    },
+    {
+      "name": "argument is explicit nil",
+      "template": "{% assign b = a | map: nil %}{% for x in b %}{% for y in x %}{{ y[0] }}:{{ y[1] }},{% endfor %}{% endfor %}",
+      "data": {
+        "a": [
+          {
+            "title": "foo"
+          },
+          {
+            "title": "bar"
+          }
+        ]
+      },
+      "result": "title:foo,title:bar,"
     },
     {
       "name": "nested arrays get flattened",


### PR DESCRIPTION
This PR updates Ruby Liquid from Shopify/liquid's main branch and changes a `map` filter test.

Since https://github.com/Shopify/liquid/pull/1944, the `map` filter returns the input array when the `property` argument is `nil`/`null` or undefined. Previously it returned a single item array with an empty string being the only item.

Aside: We're using nested for loops when outputting objects/hashes/mappings, so as to avoid testing Ruby's Hash string representation. What I really want instead is a `json` filter, so we can normalize the string representation of arrays and hashes. But `| json` is not standard.