### PR TITLE
Add a benchmark runner for Shopify/liquid

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -17,3 +17,5 @@ gem "rubocop-minitest", "~> 0.37.1"
 gem "rubocop-rake", "~> 0.7.1"
 
 gem "rake", "~> 13.2"
+
+gem "benchmark-ips", "~> 2.14"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -12,6 +12,7 @@ GEM
   specs:
     ast (2.4.3)
     base64 (0.2.0)
+    benchmark-ips (2.14.0)
     bigdecimal (3.1.9)
     hana (1.3.7)
     json (2.10.2)
@@ -67,6 +68,7 @@ PLATFORMS
 
 DEPENDENCIES
   base64 (~> 0.2.0)
+  benchmark-ips (~> 2.14)
   json
   json_schemer (~> 2.4)
   liquid!

--- a/benchmark.rb
+++ b/benchmark.rb
@@ -1,0 +1,55 @@
+# frozen_string_literal: true
+
+require "benchmark/ips"
+require "json"
+require "pathname"
+require "liquid"
+
+MemoryFileSystem = Struct.new(:templates) do
+  def read_template_file(path)
+    templates.fetch(path)
+  end
+end
+
+# A benchmark fixture
+class Fixture
+  attr_reader :templates, :data
+
+  def initialize(path)
+    @root = Pathname.new(path)
+    @name = @root.basename.to_s
+    @data = JSON.parse((@root + "data.json").read)
+    @templates = (@root + "templates").glob("*liquid").to_h do |p|
+      [p.basename.to_s, p.read]
+    end
+  end
+
+  def env
+    Liquid::Environment.build do |env|
+      env.file_system = MemoryFileSystem.new(@templates)
+    end
+  end
+end
+
+fixture = Fixture.new("benchmark_fixtures/002")
+env = fixture.env
+source = fixture.templates["index.liquid"]
+template = Liquid::Template.parse(source, environment: env, line_numbers: true)
+
+Benchmark.ips do |x|
+  # Configure the number of seconds used during
+  # the warmup phase (default 2) and calculation phase (default 5)
+  x.config(warmup: 2, time: 5)
+
+  x.report("parse:") do
+    Liquid::Template.parse(source, environment: env, line_numbers: true)
+  end
+
+  x.report("render:") do
+    template.render!
+  end
+
+  x.report("parse and render:") do
+    Liquid::Template.parse(source, environment: env, line_numbers: true).render
+  end
+end

--- a/benchmark.rb
+++ b/benchmark.rb
@@ -2,8 +2,9 @@
 
 require "benchmark/ips"
 require "json"
-require "pathname"
 require "liquid"
+require "optparse"
+require "pathname"
 
 MemoryFileSystem = Struct.new(:templates) do
   def read_template_file(path)
@@ -13,10 +14,11 @@ end
 
 # A benchmark fixture
 class Fixture
-  attr_reader :templates, :data
+  attr_reader :templates, :data, :name
 
+  # @param path [Pathname]
   def initialize(path)
-    @root = Pathname.new(path)
+    @root = path
     @name = @root.basename.to_s
     @data = JSON.parse((@root + "data.json").read)
     @templates = (@root + "templates").glob("*liquid").to_h do |p|
@@ -31,7 +33,25 @@ class Fixture
   end
 end
 
-fixture = Fixture.new("benchmark_fixtures/002")
+options = {
+  fixture: "002"
+}
+
+OptionParser.new do |parser|
+  parser.banner = <<~BANNER
+    Run one of the benchmarks in ./benchmark_fixtures.
+    Example: ruby benchmark.rb -f 002
+  BANNER
+
+  parser.on("-f FIXTURE", "--fixture FIXTURE",
+            "The name of the benchmark fixture to run. Defaults to '002'.") do |value|
+    options[:fixture] = value
+  end
+
+  parser.parse!
+end
+
+fixture = Fixture.new(Pathname.new("benchmark_fixtures") + options[:fixture])
 env = fixture.env
 source = fixture.templates["index.liquid"]
 template = Liquid::Template.parse(source, environment: env, line_numbers: true)
@@ -41,15 +61,15 @@ Benchmark.ips do |x|
   # the warmup phase (default 2) and calculation phase (default 5)
   x.config(warmup: 2, time: 5)
 
-  x.report("parse:") do
+  x.report("parse (#{fixture.name}):") do
     Liquid::Template.parse(source, environment: env, line_numbers: true)
   end
 
-  x.report("render:") do
+  x.report("render (#{fixture.name}):") do
     template.render!
   end
 
-  x.report("parse and render:") do
+  x.report("both (#{fixture.name}):") do
     Liquid::Template.parse(source, environment: env, line_numbers: true).render
   end
 end


### PR DESCRIPTION
Add `benchmark.rb` for running benchmarks from `benchmark_fixtures` with Shopify/liquid.

On an extremely old and slow laptop:

```plain
$ bundle exec ruby benchmark.rb -f 002
ruby 3.4.1 (2024-12-25 revision 48d4efcb85) +PRISM [x86_64-linux]
Warming up --------------------------------------
        parse (002):    83.000 i/100ms
       render (002):   916.000 i/100ms
         both (002):    75.000 i/100ms
Calculating -------------------------------------
        parse (002):    871.396 (± 3.2%) i/s    (1.15 ms/i) -      4.399k in   5.054146s
       render (002):      9.072k (± 2.5%) i/s  (110.23 μs/i) -     45.800k in   5.052024s
         both (002):    750.098 (± 3.3%) i/s    (1.33 ms/i) -      3.750k in   5.005064s
```