### PR TITLE
Sort test cases and tags when building

### DIFF
--- a/golden_liquid.json
+++ b/golden_liquid.json
@@ -26,10 +26,219 @@
       "result": "hello goodbye"
     },
     {
+      "name": "identifiers, at sign",
+      "template": "{{ @foo }}",
+      "data": {
+        "@foo": "hello"
+      },
+      "tags": [
+        "strict"
+      ],
+      "invalid": true
+    },
+    {
+      "name": "identifiers, capture ascii lowercase",
+      "template": "{% capture foo %}hello{% endcapture %}{{ foo }}",
+      "tags": [
+        "capture tag",
+        "strict"
+      ],
+      "result": "hello"
+    },
+    {
+      "name": "identifiers, capture ascii uppercase",
+      "template": "{% capture FOO %}hello{% endcapture %}{{ FOO }}",
+      "tags": [
+        "capture tag",
+        "strict"
+      ],
+      "result": "hello"
+    },
+    {
+      "name": "identifiers, capture digits",
+      "template": "{% capture foo1 %}hello{% endcapture %}{{ foo1 }}",
+      "tags": [
+        "capture tag",
+        "strict"
+      ],
+      "result": "hello"
+    },
+    {
+      "name": "identifiers, capture hyphens",
+      "template": "{% capture foo-a %}hello {{ bar-b }}{% endcapture %}{{ foo-a }}",
+      "data": {
+        "bar-b": "goodbye"
+      },
+      "tags": [
+        "capture tag",
+        "strict"
+      ],
+      "result": "hello goodbye"
+    },
+    {
+      "name": "identifiers, capture leading hyphen",
+      "template": "{% capture -foo %}hello {{ -bar }}{% endcapture %}{{ -foo }}",
+      "data": {
+        "-bar": "goodbye"
+      },
+      "tags": [
+        "capture tag",
+        "strict"
+      ],
+      "invalid": true
+    },
+    {
+      "name": "identifiers, capture leading underscore",
+      "template": "{% capture _foo %}hello {{ _bar }}{% endcapture %}{{ _foo }}",
+      "data": {
+        "_bar": "goodbye"
+      },
+      "tags": [
+        "capture tag",
+        "strict"
+      ],
+      "result": "hello goodbye"
+    },
+    {
+      "name": "identifiers, capture only digits",
+      "template": "{% capture 123 %}hello{% endcapture %}{{ 123 }}",
+      "tags": [
+        "capture tag",
+        "strict"
+      ],
+      "result": "123"
+    },
+    {
+      "name": "identifiers, capture only underscore",
+      "template": "{% capture _ %}hello {{ __ }}{% endcapture %}{{ _ }}",
+      "data": {
+        "__": "goodbye"
+      },
+      "tags": [
+        "capture tag",
+        "strict"
+      ],
+      "result": "hello goodbye"
+    },
+    {
+      "name": "identifiers, capture underscore",
+      "template": "{% capture foo_a %}hello {{ bar_b }}{% endcapture %}{{ foo_a }}",
+      "data": {
+        "bar_b": "goodbye"
+      },
+      "tags": [
+        "capture tag",
+        "strict"
+      ],
+      "result": "hello goodbye"
+    },
+    {
+      "name": "identifiers, decrement with a hyphen",
+      "template": "{% decrement f-oo %}{% decrement f-oo %}",
+      "tags": [
+        "decrement tag",
+        "strict"
+      ],
+      "result": "-1-2"
+    },
+    {
       "name": "identifiers, digits",
       "template": "{% assign foo1 = 'hello' %}{{ foo1 }} {{ bar2 }}",
       "data": {
         "bar2": "goodbye"
+      },
+      "tags": [
+        "assign tag",
+        "strict"
+      ],
+      "result": "hello goodbye"
+    },
+    {
+      "name": "identifiers, hyphen in for loop target",
+      "template": "{% for x in f-oo %}{{ x }}{% endfor %}",
+      "data": {
+        "f-oo": [
+          1,
+          2,
+          3
+        ]
+      },
+      "tags": [
+        "for tag",
+        "strict"
+      ],
+      "result": "123"
+    },
+    {
+      "name": "identifiers, hyphen in for loop variable",
+      "template": "{% for x-y in foo %}{{ x-y }}{% endfor %}",
+      "data": {
+        "foo": [
+          1,
+          2,
+          3
+        ]
+      },
+      "tags": [
+        "for tag",
+        "strict"
+      ],
+      "result": "123"
+    },
+    {
+      "name": "identifiers, hyphens",
+      "template": "{% assign foo-a = 'hello' %}{{ foo-a }} {{ bar-b }}",
+      "data": {
+        "bar-b": "goodbye"
+      },
+      "tags": [
+        "assign tag",
+        "strict"
+      ],
+      "result": "hello goodbye"
+    },
+    {
+      "name": "identifiers, increment with a hyphen",
+      "template": "{% increment f-oo %}{% increment f-oo %}",
+      "tags": [
+        "increment tag",
+        "strict"
+      ],
+      "result": "01"
+    },
+    {
+      "name": "identifiers, leading hyphen",
+      "template": "{% assign -foo = 'hello' %}{{ -foo }} {{ -bar }}",
+      "data": {
+        "-bar": "goodbye"
+      },
+      "tags": [
+        "assign tag",
+        "strict"
+      ],
+      "invalid": true
+    },
+    {
+      "name": "identifiers, leading hyphen in for loop target",
+      "template": "{% for x in -foo %}{{ x }}{% endfor %}",
+      "data": {
+        "-foo": [
+          1,
+          2,
+          3
+        ]
+      },
+      "tags": [
+        "for tag",
+        "strict"
+      ],
+      "invalid": true
+    },
+    {
+      "name": "identifiers, leading underscore",
+      "template": "{% assign _foo = 'hello' %}{{ _foo }} {{ _bar }}",
+      "data": {
+        "_bar": "goodbye"
       },
       "tags": [
         "assign tag",
@@ -50,42 +259,6 @@
       "result": "123 456"
     },
     {
-      "name": "identifiers, hyphens",
-      "template": "{% assign foo-a = 'hello' %}{{ foo-a }} {{ bar-b }}",
-      "data": {
-        "bar-b": "goodbye"
-      },
-      "tags": [
-        "assign tag",
-        "strict"
-      ],
-      "result": "hello goodbye"
-    },
-    {
-      "name": "identifiers, leading hyphen",
-      "template": "{% assign -foo = 'hello' %}{{ -foo }} {{ -bar }}",
-      "data": {
-        "-bar": "goodbye"
-      },
-      "tags": [
-        "strict",
-        "assign tag"
-      ],
-      "invalid": true
-    },
-    {
-      "name": "identifiers, underscore",
-      "template": "{% assign foo_a = 'hello' %}{{ foo_a }} {{ bar_b }}",
-      "data": {
-        "bar_b": "goodbye"
-      },
-      "tags": [
-        "assign tag",
-        "strict"
-      ],
-      "result": "hello goodbye"
-    },
-    {
       "name": "identifiers, only underscore",
       "template": "{% assign _ = 'hello' %}{{ _ }} {{ __ }}",
       "data": {
@@ -98,84 +271,13 @@
       "result": "hello goodbye"
     },
     {
-      "name": "identifiers, leading underscore",
-      "template": "{% assign _foo = 'hello' %}{{ _foo }} {{ _bar }}",
-      "data": {
-        "_bar": "goodbye"
-      },
+      "name": "identifiers, trailing question mark assign",
+      "template": "{% assign foo? = 'hello' %}{{ foo? }}",
       "tags": [
         "assign tag",
         "strict"
       ],
-      "result": "hello goodbye"
-    },
-    {
-      "name": "identifiers, trailing question mark assign",
-      "template": "{% assign foo? = 'hello' %}{{ foo? }}",
-      "tags": [
-        "strict",
-        "assign tag"
-      ],
       "invalid": true
-    },
-    {
-      "name": "identifiers, trailing question mark output",
-      "template": "{{ bar? }}",
-      "data": {
-        "bar?": "goodbye"
-      },
-      "tags": [
-        "strict"
-      ],
-      "result": "goodbye"
-    },
-    {
-      "name": "identifiers, hyphen in for loop target",
-      "template": "{% for x in f-oo %}{{ x }}{% endfor %}",
-      "data": {
-        "f-oo": [
-          1,
-          2,
-          3
-        ]
-      },
-      "tags": [
-        "for tag",
-        "strict"
-      ],
-      "result": "123"
-    },
-    {
-      "name": "identifiers, leading hyphen in for loop target",
-      "template": "{% for x in -foo %}{{ x }}{% endfor %}",
-      "data": {
-        "-foo": [
-          1,
-          2,
-          3
-        ]
-      },
-      "tags": [
-        "strict",
-        "for tag"
-      ],
-      "invalid": true
-    },
-    {
-      "name": "identifiers, hyphen in for loop variable",
-      "template": "{% for x-y in foo %}{{ x-y }}{% endfor %}",
-      "data": {
-        "foo": [
-          1,
-          2,
-          3
-        ]
-      },
-      "tags": [
-        "for tag",
-        "strict"
-      ],
-      "result": "123"
     },
     {
       "name": "identifiers, trailing question mark in for loop target",
@@ -210,126 +312,54 @@
       "result": "123"
     },
     {
-      "name": "identifiers, increment with a hyphen",
-      "template": "{% increment f-oo %}{% increment f-oo %}",
-      "tags": [
-        "increment tag",
-        "strict"
-      ],
-      "result": "01"
-    },
-    {
-      "name": "identifiers, decrement with a hyphen",
-      "template": "{% decrement f-oo %}{% decrement f-oo %}",
-      "tags": [
-        "decrement tag",
-        "strict"
-      ],
-      "result": "-1-2"
-    },
-    {
-      "name": "identifiers, capture ascii lowercase",
-      "template": "{% capture foo %}hello{% endcapture %}{{ foo }}",
-      "tags": [
-        "capture tag",
-        "strict"
-      ],
-      "result": "hello"
-    },
-    {
-      "name": "identifiers, capture ascii uppercase",
-      "template": "{% capture FOO %}hello{% endcapture %}{{ FOO }}",
-      "tags": [
-        "capture tag",
-        "strict"
-      ],
-      "result": "hello"
-    },
-    {
-      "name": "identifiers, capture digits",
-      "template": "{% capture foo1 %}hello{% endcapture %}{{ foo1 }}",
-      "tags": [
-        "capture tag",
-        "strict"
-      ],
-      "result": "hello"
-    },
-    {
-      "name": "identifiers, capture only digits",
-      "template": "{% capture 123 %}hello{% endcapture %}{{ 123 }}",
-      "tags": [
-        "capture tag",
-        "strict"
-      ],
-      "result": "123"
-    },
-    {
-      "name": "identifiers, capture hyphens",
-      "template": "{% capture foo-a %}hello {{ bar-b }}{% endcapture %}{{ foo-a }}",
+      "name": "identifiers, trailing question mark output",
+      "template": "{{ bar? }}",
       "data": {
-        "bar-b": "goodbye"
+        "bar?": "goodbye"
       },
       "tags": [
-        "capture tag",
         "strict"
       ],
-      "result": "hello goodbye"
+      "result": "goodbye"
     },
     {
-      "name": "identifiers, capture leading hyphen",
-      "template": "{% capture -foo %}hello {{ -bar }}{% endcapture %}{{ -foo }}",
-      "data": {
-        "-bar": "goodbye"
-      },
-      "tags": [
-        "strict",
-        "capture tag"
-      ],
-      "invalid": true
-    },
-    {
-      "name": "identifiers, capture underscore",
-      "template": "{% capture foo_a %}hello {{ bar_b }}{% endcapture %}{{ foo_a }}",
+      "name": "identifiers, underscore",
+      "template": "{% assign foo_a = 'hello' %}{{ foo_a }} {{ bar_b }}",
       "data": {
         "bar_b": "goodbye"
       },
       "tags": [
-        "capture tag",
+        "assign tag",
         "strict"
       ],
       "result": "hello goodbye"
     },
     {
-      "name": "identifiers, capture only underscore",
-      "template": "{% capture _ %}hello {{ __ }}{% endcapture %}{{ _ }}",
-      "data": {
-        "__": "goodbye"
-      },
+      "name": "illegal, no addition operator",
+      "template": "{% assign x = 1 + 2 %}{{ x }}",
       "tags": [
-        "capture tag",
+        "absent",
+        "assign tag",
         "strict"
       ],
-      "result": "hello goodbye"
+      "invalid": true
     },
     {
-      "name": "identifiers, capture leading underscore",
-      "template": "{% capture _foo %}hello {{ _bar }}{% endcapture %}{{ _foo }}",
-      "data": {
-        "_bar": "goodbye"
-      },
+      "name": "illegal, no multiplication operator",
+      "template": "{% assign x = 2 %}{{ x * 3 }}",
       "tags": [
-        "capture tag",
+        "absent",
+        "assign tag",
         "strict"
       ],
-      "result": "hello goodbye"
+      "invalid": true
     },
     {
-      "name": "identifiers, at sign",
-      "template": "{{ @foo }}",
-      "data": {
-        "@foo": "hello"
-      },
+      "name": "illegal, no subtraction operator",
+      "template": "{% assign x = 1 - 2 %}{{ x }}",
       "tags": [
+        "absent",
+        "assign tag",
         "strict"
       ],
       "invalid": true
@@ -341,94 +371,6 @@
         "strict"
       ],
       "invalid": true
-    },
-    {
-      "name": "illegal, no addition operator",
-      "template": "{% assign x = 1 + 2 %}{{ x }}",
-      "tags": [
-        "strict",
-        "absent",
-        "assign tag"
-      ],
-      "invalid": true
-    },
-    {
-      "name": "illegal, no subtraction operator",
-      "template": "{% assign x = 1 - 2 %}{{ x }}",
-      "tags": [
-        "strict",
-        "absent",
-        "assign tag"
-      ],
-      "invalid": true
-    },
-    {
-      "name": "illegal, no multiplication operator",
-      "template": "{% assign x = 2 %}{{ x * 3 }}",
-      "tags": [
-        "strict",
-        "absent",
-        "assign tag"
-      ],
-      "invalid": true
-    },
-    {
-      "name": "output, render a string literal",
-      "template": "{{ 'hello' }}",
-      "result": "hello"
-    },
-    {
-      "name": "output, render an integer literal",
-      "template": "{{ 123 }}",
-      "result": "123"
-    },
-    {
-      "name": "output, render a negative integer literal",
-      "template": "{{ -123 }}",
-      "result": "-123"
-    },
-    {
-      "name": "output, render a float literal",
-      "template": "{{ 1.23 }}",
-      "result": "1.23"
-    },
-    {
-      "name": "output, render nil",
-      "template": "{{ nil }}",
-      "result": ""
-    },
-    {
-      "name": "output, render a variable from the global namespace",
-      "template": "{{ product.title }}",
-      "data": {
-        "product": {
-          "title": "foo"
-        }
-      },
-      "result": "foo"
-    },
-    {
-      "name": "output, render a variable from the local namespace",
-      "template": "{% assign name = 'Brian' %}{{ name }}",
-      "result": "Brian",
-      "tags": [
-        "assign tag"
-      ]
-    },
-    {
-      "name": "output, render an undefined variable",
-      "template": "{{ age }}",
-      "result": ""
-    },
-    {
-      "name": "output, render an undefined property",
-      "template": "{{ product.age }}",
-      "data": {
-        "product": {
-          "title": "foo"
-        }
-      },
-      "result": ""
     },
     {
       "name": "output, access an array item by index",
@@ -457,6 +399,11 @@
       "result": "sports"
     },
     {
+      "name": "output, access an undefined variable by index",
+      "template": "{{ nosuchthing[0] }}",
+      "result": ""
+    },
+    {
       "name": "output, access array item by index stored in a local variable",
       "template": "{% assign i = 1 %}{{ product.tags[i] }}",
       "data": {
@@ -473,33 +420,16 @@
       ]
     },
     {
-      "name": "output, render a global variable with a filter",
-      "template": "{{ product.title | upcase }}",
+      "name": "output, array index out of bounds",
+      "template": "{{ a[3] }}",
       "data": {
-        "product": {
-          "title": "foo"
-        }
+        "a": [
+          1,
+          2,
+          3
+        ]
       },
-      "result": "FOO",
-      "tags": [
-        "upcase filter"
-      ]
-    },
-    {
-      "name": "output, dump an array from the global context",
-      "template": "{{ product.tags | join: '#' }}",
-      "data": {
-        "product": {
-          "tags": [
-            "sports",
-            "garden"
-          ]
-        }
-      },
-      "result": "sports#garden",
-      "tags": [
-        "join filter"
-      ]
+      "result": ""
     },
     {
       "name": "output, assign a variable the value of an existing variable",
@@ -511,105 +441,24 @@
       ]
     },
     {
-      "name": "output, traverse variables with bracketed identifiers",
-      "template": "{{ site.data.menu[include.menu][include.locale] }}",
+      "name": "output, bracketed variable resolves to a string",
+      "template": "{{ foo[something] }}",
       "data": {
-        "site": {
-          "data": {
-            "menu": {
-              "foo": {
-                "bar": "it works!"
-              }
-            }
-          }
+        "foo": {
+          "hello": "goodbye"
         },
-        "include": {
-          "menu": "foo",
-          "locale": "bar"
-        }
+        "something": "hello"
       },
-      "result": "it works!"
+      "result": "goodbye"
     },
     {
-      "name": "output, render a default given a literal false",
-      "template": "{{ false | default: 'bar' }}",
-      "result": "bar",
-      "tags": [
-        "default filter"
-      ]
-    },
-    {
-      "name": "output, render a default given a literal false with 'allow false' equal to true",
-      "template": "{{ false | default: 'bar', allow_false: true }}",
-      "result": "false",
-      "tags": [
-        "default filter"
-      ]
-    },
-    {
-      "name": "output, render a default given a literal false with 'allow false' equal to false",
-      "template": "{{ false | default: 'bar', allow_false: false }}",
-      "result": "bar",
-      "tags": [
-        "default filter"
-      ]
-    },
-    {
-      "name": "output, unexpected left value for the `join` filter passes through",
-      "template": "{{ 12 | join: '#' }}",
-      "result": "12",
-      "tags": [
-        "join filter"
-      ]
-    },
-    {
-      "name": "output, render an output start sequence as a string literal",
-      "template": "{{ '{{' }}",
-      "result": "{{"
-    },
-    {
-      "name": "output, access an undefined variable by index",
-      "template": "{{ nosuchthing[0] }}",
-      "result": ""
-    },
-    {
-      "name": "output, render a range object",
-      "template": "{{ (1..5) | join: '#' }}",
-      "result": "1#2#3#4#5",
-      "tags": [
-        "join filter"
-      ]
-    },
-    {
-      "name": "output, render a range object that uses a float",
-      "template": "{{ (1.4..5) | join: '#' }}",
-      "result": "1#2#3#4#5",
-      "tags": [
-        "join filter"
-      ]
-    },
-    {
-      "name": "output, render a range object that uses an identifier",
-      "template": "{{ (foo..5) | join: '#' }}",
+      "name": "output, bracketed variable resolves to a string without leading identifier",
+      "template": "{{ [something] }}",
       "data": {
-        "foo": 2
+        "something": "hello",
+        "hello": "goodbye"
       },
-      "result": "2#3#4#5",
-      "tags": [
-        "join filter"
-      ]
-    },
-    {
-      "name": "output, reverse a range",
-      "template": "{{ (foo..5) | reverse | join: '#' }}",
-      "data": {
-        "foo": 2
-      },
-      "result": "5#4#3#2",
-      "tags": [
-        "join filter",
-        "reverse filter"
-      ]
+      "result": "goodbye"
     },
     {
       "name": "output, chained bracketed identifier index",
@@ -676,24 +525,45 @@
       "invalid": true
     },
     {
-      "name": "output, bracketed variable resolves to a string",
-      "template": "{{ foo[something] }}",
+      "name": "output, double dot",
+      "template": "{{ foo..bar }}",
       "data": {
         "foo": {
-          "hello": "goodbye"
-        },
-        "something": "hello"
+          "bar": 42
+        }
       },
-      "result": "goodbye"
+      "tags": [
+        "strict"
+      ],
+      "invalid": true
     },
     {
-      "name": "output, bracketed variable resolves to a string without leading identifier",
-      "template": "{{ [something] }}",
+      "name": "output, dump an array from the global context",
+      "template": "{{ product.tags | join: '#' }}",
       "data": {
-        "something": "hello",
-        "hello": "goodbye"
+        "product": {
+          "tags": [
+            "sports",
+            "garden"
+          ]
+        }
       },
-      "result": "goodbye"
+      "result": "sports#garden",
+      "tags": [
+        "join filter"
+      ]
+    },
+    {
+      "name": "output, negative array index out of bounds",
+      "template": "{{ a[-4] }}",
+      "data": {
+        "a": [
+          1,
+          2,
+          3
+        ]
+      },
+      "result": ""
     },
     {
       "name": "output, nested bracketed variable resolving to a string",
@@ -730,6 +600,145 @@
       "result": "42"
     },
     {
+      "name": "output, render a default given a literal false",
+      "template": "{{ false | default: 'bar' }}",
+      "result": "bar",
+      "tags": [
+        "default filter"
+      ]
+    },
+    {
+      "name": "output, render a default given a literal false with 'allow false' equal to false",
+      "template": "{{ false | default: 'bar', allow_false: false }}",
+      "result": "bar",
+      "tags": [
+        "default filter"
+      ]
+    },
+    {
+      "name": "output, render a default given a literal false with 'allow false' equal to true",
+      "template": "{{ false | default: 'bar', allow_false: true }}",
+      "result": "false",
+      "tags": [
+        "default filter"
+      ]
+    },
+    {
+      "name": "output, render a float literal",
+      "template": "{{ 1.23 }}",
+      "result": "1.23"
+    },
+    {
+      "name": "output, render a global variable with a filter",
+      "template": "{{ product.title | upcase }}",
+      "data": {
+        "product": {
+          "title": "foo"
+        }
+      },
+      "result": "FOO",
+      "tags": [
+        "upcase filter"
+      ]
+    },
+    {
+      "name": "output, render a negative integer literal",
+      "template": "{{ -123 }}",
+      "result": "-123"
+    },
+    {
+      "name": "output, render a range object",
+      "template": "{{ (1..5) | join: '#' }}",
+      "result": "1#2#3#4#5",
+      "tags": [
+        "join filter"
+      ]
+    },
+    {
+      "name": "output, render a range object that uses a float",
+      "template": "{{ (1.4..5) | join: '#' }}",
+      "result": "1#2#3#4#5",
+      "tags": [
+        "join filter"
+      ]
+    },
+    {
+      "name": "output, render a range object that uses an identifier",
+      "template": "{{ (foo..5) | join: '#' }}",
+      "data": {
+        "foo": 2
+      },
+      "result": "2#3#4#5",
+      "tags": [
+        "join filter"
+      ]
+    },
+    {
+      "name": "output, render a string literal",
+      "template": "{{ 'hello' }}",
+      "result": "hello"
+    },
+    {
+      "name": "output, render a variable from the global namespace",
+      "template": "{{ product.title }}",
+      "data": {
+        "product": {
+          "title": "foo"
+        }
+      },
+      "result": "foo"
+    },
+    {
+      "name": "output, render a variable from the local namespace",
+      "template": "{% assign name = 'Brian' %}{{ name }}",
+      "result": "Brian",
+      "tags": [
+        "assign tag"
+      ]
+    },
+    {
+      "name": "output, render an integer literal",
+      "template": "{{ 123 }}",
+      "result": "123"
+    },
+    {
+      "name": "output, render an output start sequence as a string literal",
+      "template": "{{ '{{' }}",
+      "result": "{{"
+    },
+    {
+      "name": "output, render an undefined property",
+      "template": "{{ product.age }}",
+      "data": {
+        "product": {
+          "title": "foo"
+        }
+      },
+      "result": ""
+    },
+    {
+      "name": "output, render an undefined variable",
+      "template": "{{ age }}",
+      "result": ""
+    },
+    {
+      "name": "output, render nil",
+      "template": "{{ nil }}",
+      "result": ""
+    },
+    {
+      "name": "output, reverse a range",
+      "template": "{{ (foo..5) | reverse | join: '#' }}",
+      "data": {
+        "foo": 2
+      },
+      "result": "5#4#3#2",
+      "tags": [
+        "join filter",
+        "reverse filter"
+      ]
+    },
+    {
       "name": "output, top-level quoted, bracketed variable name with whitespace",
       "template": "{{ ['bar baz'] }}",
       "data": {
@@ -748,8 +757,36 @@
       "result": "42"
     },
     {
-      "name": "output, whitespace between word and dot",
-      "template": "{{ foo \n\t.bar }}",
+      "name": "output, traverse variables with bracketed identifiers",
+      "template": "{{ site.data.menu[include.menu][include.locale] }}",
+      "data": {
+        "site": {
+          "data": {
+            "menu": {
+              "foo": {
+                "bar": "it works!"
+              }
+            }
+          }
+        },
+        "include": {
+          "menu": "foo",
+          "locale": "bar"
+        }
+      },
+      "result": "it works!"
+    },
+    {
+      "name": "output, unexpected left value for the `join` filter passes through",
+      "template": "{{ 12 | join: '#' }}",
+      "result": "12",
+      "tags": [
+        "join filter"
+      ]
+    },
+    {
+      "name": "output, whitespace between bracket notation",
+      "template": "{{ ['foo'] \n\t['bar'] }}",
       "data": {
         "foo": {
           "bar": 42
@@ -768,8 +805,8 @@
       "result": "42"
     },
     {
-      "name": "output, whitespace between bracket notation",
-      "template": "{{ ['foo'] \n\t['bar'] }}",
+      "name": "output, whitespace between word and dot",
+      "template": "{{ foo \n\t.bar }}",
       "data": {
         "foo": {
           "bar": 42
@@ -791,50 +828,13 @@
       "invalid": true
     },
     {
-      "name": "output, double dot",
-      "template": "{{ foo..bar }}",
-      "data": {
-        "foo": {
-          "bar": 42
-        }
-      },
-      "tags": [
-        "strict"
-      ],
-      "invalid": true
-    },
-    {
-      "name": "output, array index out of bounds",
-      "template": "{{ a[3] }}",
-      "data": {
-        "a": [
-          1,
-          2,
-          3
-        ]
-      },
-      "result": ""
-    },
-    {
-      "name": "output, negative array index out of bounds",
-      "template": "{{ a[-4] }}",
-      "data": {
-        "a": [
-          1,
-          2,
-          3
-        ]
-      },
-      "result": ""
-    },
-    {
-      "name": "range, start is not a number",
+      "name": "range, end is less than start",
       "template": "{{ (start..end) | join: '#' }}",
       "data": {
-        "start": "foo",
-        "end": 5
+        "start": 5,
+        "end": 1
       },
-      "result": "0#1#2#3#4#5",
+      "result": "",
       "tags": [
         "join filter"
       ]
@@ -852,25 +852,9 @@
       ]
     },
     {
-      "name": "range, end is less than start",
-      "template": "{{ (start..end) | join: '#' }}",
-      "data": {
-        "start": 5,
-        "end": 1
-      },
-      "result": "",
-      "tags": [
-        "join filter"
-      ]
-    },
-    {
-      "name": "range, start is negative",
-      "template": "{{ (start..end) | join: '#' }}",
-      "data": {
-        "start": -5,
-        "end": 1
-      },
-      "result": "-5#-4#-3#-2#-1#0#1",
+      "name": "range, integer literals",
+      "template": "{{ (1..5) | join: '#' }}",
+      "result": "1#2#3#4#5",
       "tags": [
         "join filter"
       ]
@@ -888,16 +872,32 @@
       ]
     },
     {
-      "name": "range, integer literals",
-      "template": "{{ (1..5) | join: '#' }}",
-      "result": "1#2#3#4#5",
+      "name": "range, start is negative",
+      "template": "{{ (start..end) | join: '#' }}",
+      "data": {
+        "start": -5,
+        "end": 1
+      },
+      "result": "-5#-4#-3#-2#-1#0#1",
       "tags": [
         "join filter"
       ]
     },
     {
-      "name": "range, whitespace before start",
-      "template": "{{ ( \n\t1..5) | join: '#' }}",
+      "name": "range, start is not a number",
+      "template": "{{ (start..end) | join: '#' }}",
+      "data": {
+        "start": "foo",
+        "end": 5
+      },
+      "result": "0#1#2#3#4#5",
+      "tags": [
+        "join filter"
+      ]
+    },
+    {
+      "name": "range, whitespace after dots",
+      "template": "{{ (1.. \n\t5) | join: '#' }}",
       "result": "1#2#3#4#5",
       "tags": [
         "join filter"
@@ -906,22 +906,6 @@
     {
       "name": "range, whitespace after stop",
       "template": "{{ (1..5 \n\t) | join: '#' }}",
-      "result": "1#2#3#4#5",
-      "tags": [
-        "join filter"
-      ]
-    },
-    {
-      "name": "range, whitespace before dots",
-      "template": "{{ (1 \n\t..5) | join: '#' }}",
-      "result": "1#2#3#4#5",
-      "tags": [
-        "join filter"
-      ]
-    },
-    {
-      "name": "range, whitespace after dots",
-      "template": "{{ (1.. \n\t5) | join: '#' }}",
       "result": "1#2#3#4#5",
       "tags": [
         "join filter"
@@ -945,6 +929,33 @@
       "result": "1,2,3,4,5,"
     },
     {
+      "name": "range, whitespace before dots",
+      "template": "{{ (1 \n\t..5) | join: '#' }}",
+      "result": "1#2#3#4#5",
+      "tags": [
+        "join filter"
+      ]
+    },
+    {
+      "name": "range, whitespace before start",
+      "template": "{{ ( \n\t1..5) | join: '#' }}",
+      "result": "1#2#3#4#5",
+      "tags": [
+        "join filter"
+      ]
+    },
+    {
+      "name": "special, first of a string",
+      "template": "{{ s.first }}",
+      "data": {
+        "s": "hello"
+      },
+      "results": [
+        "h",
+        ""
+      ]
+    },
+    {
       "name": "special, first of an array",
       "template": "{{ a.first }}",
       "data": {
@@ -957,46 +968,14 @@
       "result": "3"
     },
     {
-      "name": "special, last of an array",
-      "template": "{{ a.last }}",
+      "name": "special, first of an empty object",
+      "template": "{{ obj.first | join: '#' }}",
       "data": {
-        "a": [
-          3,
-          2,
-          1
-        ]
+        "obj": {}
       },
-      "result": "1"
-    },
-    {
-      "name": "special, size of an array",
-      "template": "{{ a.size }}",
-      "data": {
-        "a": [
-          3,
-          2,
-          1
-        ]
-      },
-      "result": "3"
-    },
-    {
-      "name": "special, size of a string",
-      "template": "{{ s.size }}",
-      "data": {
-        "s": "hello"
-      },
-      "result": "5"
-    },
-    {
-      "name": "special, first of a string",
-      "template": "{{ s.first }}",
-      "data": {
-        "s": "hello"
-      },
-      "results": [
-        "h",
-        ""
+      "result": "",
+      "tags": [
+        "join filter"
       ]
     },
     {
@@ -1014,26 +993,15 @@
       ]
     },
     {
-      "name": "special, first of an empty object",
-      "template": "{{ obj.first | join: '#' }}",
+      "name": "special, first of an object with a first property",
+      "template": "{{ obj.first }}",
       "data": {
-        "obj": {}
+        "obj": {
+          "a": 1,
+          "first": 99
+        }
       },
-      "result": "",
-      "tags": [
-        "join filter"
-      ]
-    },
-    {
-      "name": "special, last of a string",
-      "template": "{{ s.last }}",
-      "data": {
-        "s": "hello"
-      },
-      "results": [
-        "o",
-        ""
-      ]
+      "result": "99"
     },
     {
       "name": "special, last of a object",
@@ -1047,25 +1015,27 @@
       "result": ""
     },
     {
-      "name": "special, size of an object with a size property",
-      "template": "{{ obj.size }}",
+      "name": "special, last of a string",
+      "template": "{{ s.last }}",
       "data": {
-        "obj": {
-          "size": 99
-        }
+        "s": "hello"
       },
-      "result": "99"
+      "results": [
+        "o",
+        ""
+      ]
     },
     {
-      "name": "special, first of an object with a first property",
-      "template": "{{ obj.first }}",
+      "name": "special, last of an array",
+      "template": "{{ a.last }}",
       "data": {
-        "obj": {
-          "a": 1,
-          "first": 99
-        }
+        "a": [
+          3,
+          2,
+          1
+        ]
       },
-      "result": "99"
+      "result": "1"
     },
     {
       "name": "special, last of an object with a last property",
@@ -1080,60 +1050,102 @@
       "result": "99"
     },
     {
+      "name": "special, size of a string",
+      "template": "{{ s.size }}",
+      "data": {
+        "s": "hello"
+      },
+      "result": "5"
+    },
+    {
+      "name": "special, size of an array",
+      "template": "{{ a.size }}",
+      "data": {
+        "a": [
+          3,
+          2,
+          1
+        ]
+      },
+      "result": "3"
+    },
+    {
+      "name": "special, size of an object with a size property",
+      "template": "{{ obj.size }}",
+      "data": {
+        "obj": {
+          "size": 99
+        }
+      },
+      "result": "99"
+    },
+    {
       "name": "special, size of undefined",
       "template": "{{ nosuchthing.last }}",
       "result": ""
     },
     {
-      "name": "whitespace control, white space control with newlines and spaces",
-      "template": "\n{% if customer -%}\nWelcome back,  {{ customer.first_name -}} !\n {%- endif -%}",
-      "data": {
-        "customer": {
-          "first_name": "Holly"
-        }
-      },
-      "result": "\nWelcome back,  Holly!",
+      "name": "whitespace control, don't suppress whitespace only blocks containing echo",
+      "template": "!{% if true %}\n\n{% assign bar = 'foo' %}\n    {% echo '' %}\n\n    {% assign foo = 'bar' %}\n\n\n\n{% endif %}!",
+      "result": "!\n\n\n    \n\n    \n\n\n\n!",
       "tags": [
+        "assign tag",
+        "echo tag",
         "if tag"
       ]
     },
     {
-      "name": "whitespace control, white space control with carriage return and spaces",
-      "template": "\r{% if customer -%}\rWelcome back,  {{ customer.first_name -}} !\r {%- endif -%}",
-      "data": {
-        "customer": {
-          "first_name": "Holly"
-        }
-      },
-      "result": "\rWelcome back,  Holly!",
+      "name": "whitespace control, don't suppress whitespace only blocks containing output",
+      "template": "!{% if true %}\n\n{% assign bar = 'foo' %}\n    {{ '' }}\n\n    {% assign foo = 'bar' %}\n\n\n\n{% endif %}!",
+      "result": "!\n\n\n    \n\n    \n\n\n\n!",
       "tags": [
+        "assign tag",
         "if tag"
       ]
     },
     {
-      "name": "whitespace control, white space control with  carriage return, newline and spaces",
-      "template": "\r\n{% if customer -%}\r\nWelcome back,  {{ customer.first_name -}} !\r\n {%- endif -%}",
-      "data": {
-        "customer": {
-          "first_name": "Holly"
-        }
-      },
-      "result": "\r\nWelcome back,  Holly!",
+      "name": "whitespace control, don't suppress whitespace only blocks containing output in nested block",
+      "template": "!{% if 1 %}\n\n{% assign bar = 'foo' %}\n{% if 2 %}\n    {{ '' }}\n\n    {% assign foo = 'bar' %}\n\n{% endif %}\n\n\n{% endif %}!",
+      "result": "!\n\n\n\n    \n\n    \n\n\n\n\n!",
       "tags": [
+        "assign tag",
         "if tag"
       ]
     },
     {
-      "name": "whitespace control, white space control with newlines, tabs and spaces",
-      "template": "\n\t{% if customer -%}\t\nWelcome back,  {{ customer.first_name -}}\t !\r\n {%- endif -%}",
-      "data": {
-        "customer": {
-          "first_name": "Holly"
-        }
-      },
-      "result": "\n\tWelcome back,  Holly!",
+      "name": "whitespace control, don't suppress whitespace only blocks containing output in unreachable blocks",
+      "template": "!{% if 1 %}\n\n{% assign bar = 'foo' %}\n{% if true %}\n\n    {% assign foo = 'bar' %}\n\n{% else %}\n    {{ '' }}\n{% endif %}\n\n\n{% endif %}!",
+      "result": "!\n\n\n\n\n    \n\n\n\n\n!",
       "tags": [
+        "assign tag",
         "if tag"
+      ]
+    },
+    {
+      "name": "whitespace control, don't suppress whitespace only case blocks containing output",
+      "template": "!{% assign x = 1 %}{% case x %}\n\n  {% when 1 %}\n    {% assign foo = 'bar' %}\n\n  {% when 2 %}\n    {{ '' }}\n\n{% endcase %}!",
+      "result": "!\n    \n\n  !",
+      "tags": [
+        "assign tag",
+        "case tag"
+      ]
+    },
+    {
+      "name": "whitespace control, don't suppress whitespace only unless blocks containing output in nested blocks",
+      "template": "!{% unless false %}\n\n{% assign bar = 'foo' %}\n{% unless false %}\n    {{ '' }}\n\n    {% assign foo = 'bar' %}\n\n{% endunless %}\n\n\n{% endunless %}!",
+      "result": "!\n\n\n\n    \n\n    \n\n\n\n\n!",
+      "tags": [
+        "assign tag",
+        "unless tag"
+      ]
+    },
+    {
+      "name": "whitespace control, suppress whitespace only case blocks",
+      "template": "!{% assign x = 1 %}{% case x %}\n\n  {% when 1 %}\n    {% assign foo = 'bar' %}\n\n\n{% endcase %}!",
+      "result": "!!",
+      "tags": [
+        "assign tag",
+        "case tag"
       ]
     },
     {
@@ -1155,57 +1167,11 @@
       ]
     },
     {
-      "name": "whitespace control, suppress whitespace only case blocks",
-      "template": "!{% assign x = 1 %}{% case x %}\n\n  {% when 1 %}\n    {% assign foo = 'bar' %}\n\n\n{% endcase %}!",
+      "name": "whitespace control, suppress whitespace surrounding a capture block",
+      "template": "!{% if true %}\n\n{% capture foo %}\n{{ '' }}\n{% endcapture %}\n\n{% endif %}!",
       "result": "!!",
       "tags": [
-        "assign tag",
-        "case tag"
-      ]
-    },
-    {
-      "name": "whitespace control, don't suppress whitespace only blocks containing output",
-      "template": "!{% if true %}\n\n{% assign bar = 'foo' %}\n    {{ '' }}\n\n    {% assign foo = 'bar' %}\n\n\n\n{% endif %}!",
-      "result": "!\n\n\n    \n\n    \n\n\n\n!",
-      "tags": [
-        "assign tag",
-        "if tag"
-      ]
-    },
-    {
-      "name": "whitespace control, don't suppress whitespace only blocks containing echo",
-      "template": "!{% if true %}\n\n{% assign bar = 'foo' %}\n    {% echo '' %}\n\n    {% assign foo = 'bar' %}\n\n\n\n{% endif %}!",
-      "result": "!\n\n\n    \n\n    \n\n\n\n!",
-      "tags": [
-        "assign tag",
-        "echo tag",
-        "if tag"
-      ]
-    },
-    {
-      "name": "whitespace control, don't suppress whitespace only blocks containing output in nested block",
-      "template": "!{% if 1 %}\n\n{% assign bar = 'foo' %}\n{% if 2 %}\n    {{ '' }}\n\n    {% assign foo = 'bar' %}\n\n{% endif %}\n\n\n{% endif %}!",
-      "result": "!\n\n\n\n    \n\n    \n\n\n\n\n!",
-      "tags": [
-        "assign tag",
-        "if tag"
-      ]
-    },
-    {
-      "name": "whitespace control, don't suppress whitespace only unless blocks containing output in nested blocks",
-      "template": "!{% unless false %}\n\n{% assign bar = 'foo' %}\n{% unless false %}\n    {{ '' }}\n\n    {% assign foo = 'bar' %}\n\n{% endunless %}\n\n\n{% endunless %}!",
-      "result": "!\n\n\n\n    \n\n    \n\n\n\n\n!",
-      "tags": [
-        "assign tag",
-        "unless tag"
-      ]
-    },
-    {
-      "name": "whitespace control, don't suppress whitespace only blocks containing output in unreachable blocks",
-      "template": "!{% if 1 %}\n\n{% assign bar = 'foo' %}\n{% if true %}\n\n    {% assign foo = 'bar' %}\n\n{% else %}\n    {{ '' }}\n{% endif %}\n\n\n{% endif %}!",
-      "result": "!\n\n\n\n\n    \n\n\n\n\n!",
-      "tags": [
-        "assign tag",
+        "capture tag",
         "if tag"
       ]
     },
@@ -1219,21 +1185,55 @@
       ]
     },
     {
-      "name": "whitespace control, suppress whitespace surrounding a capture block",
-      "template": "!{% if true %}\n\n{% capture foo %}\n{{ '' }}\n{% endcapture %}\n\n{% endif %}!",
-      "result": "!!",
+      "name": "whitespace control, white space control with  carriage return, newline and spaces",
+      "template": "\r\n{% if customer -%}\r\nWelcome back,  {{ customer.first_name -}} !\r\n {%- endif -%}",
+      "data": {
+        "customer": {
+          "first_name": "Holly"
+        }
+      },
+      "result": "\r\nWelcome back,  Holly!",
       "tags": [
-        "capture tag",
         "if tag"
       ]
     },
     {
-      "name": "whitespace control, don't suppress whitespace only case blocks containing output",
-      "template": "!{% assign x = 1 %}{% case x %}\n\n  {% when 1 %}\n    {% assign foo = 'bar' %}\n\n  {% when 2 %}\n    {{ '' }}\n\n{% endcase %}!",
-      "result": "!\n    \n\n  !",
+      "name": "whitespace control, white space control with carriage return and spaces",
+      "template": "\r{% if customer -%}\rWelcome back,  {{ customer.first_name -}} !\r {%- endif -%}",
+      "data": {
+        "customer": {
+          "first_name": "Holly"
+        }
+      },
+      "result": "\rWelcome back,  Holly!",
       "tags": [
-        "assign tag",
-        "case tag"
+        "if tag"
+      ]
+    },
+    {
+      "name": "whitespace control, white space control with newlines and spaces",
+      "template": "\n{% if customer -%}\nWelcome back,  {{ customer.first_name -}} !\n {%- endif -%}",
+      "data": {
+        "customer": {
+          "first_name": "Holly"
+        }
+      },
+      "result": "\nWelcome back,  Holly!",
+      "tags": [
+        "if tag"
+      ]
+    },
+    {
+      "name": "whitespace control, white space control with newlines, tabs and spaces",
+      "template": "\n\t{% if customer -%}\t\nWelcome back,  {{ customer.first_name -}}\t !\r\n {%- endif -%}",
+      "data": {
+        "customer": {
+          "first_name": "Holly"
+        }
+      },
+      "result": "\n\tWelcome back,  Holly!",
+      "tags": [
+        "if tag"
       ]
     },
     {
@@ -1242,9 +1242,9 @@
       "result": "! {{ hello }} !\n!{{ hello }}!"
     },
     {
-      "name": "filters, abs, positive integer",
-      "template": "{{ 5 | abs }}",
-      "result": "5",
+      "name": "filters, abs, negative float",
+      "template": "{{ -5.4 | abs }}",
+      "result": "5.4",
       "tags": [
         "abs filter"
       ]
@@ -1258,54 +1258,6 @@
       ]
     },
     {
-      "name": "filters, abs, positive float",
-      "template": "{{ 5.4 | abs }}",
-      "result": "5.4",
-      "tags": [
-        "abs filter"
-      ]
-    },
-    {
-      "name": "filters, abs, negative float",
-      "template": "{{ -5.4 | abs }}",
-      "result": "5.4",
-      "tags": [
-        "abs filter"
-      ]
-    },
-    {
-      "name": "filters, abs, zero",
-      "template": "{{ 0 | abs }}",
-      "result": "0",
-      "tags": [
-        "abs filter"
-      ]
-    },
-    {
-      "name": "filters, abs, positive string integer",
-      "template": "{{ '5' | abs }}",
-      "result": "5",
-      "tags": [
-        "abs filter"
-      ]
-    },
-    {
-      "name": "filters, abs, negative string integer",
-      "template": "{{ '-5' | abs }}",
-      "result": "5",
-      "tags": [
-        "abs filter"
-      ]
-    },
-    {
-      "name": "filters, abs, positive string float",
-      "template": "{{ '5.1' | abs }}",
-      "result": "5.1",
-      "tags": [
-        "abs filter"
-      ]
-    },
-    {
       "name": "filters, abs, negative string float",
       "template": "{{ '-5.1' | abs }}",
       "result": "5.1",
@@ -1314,17 +1266,9 @@
       ]
     },
     {
-      "name": "filters, abs, unexpected argument",
-      "template": "{{ -3 | abs: 1 }}",
-      "invalid": true,
-      "tags": [
-        "abs filter"
-      ]
-    },
-    {
-      "name": "filters, abs, string not a number",
-      "template": "{{ 'hello' | abs }}",
-      "result": "0",
+      "name": "filters, abs, negative string integer",
+      "template": "{{ '-5' | abs }}",
+      "result": "5",
       "tags": [
         "abs filter"
       ]
@@ -1341,6 +1285,46 @@
       ]
     },
     {
+      "name": "filters, abs, positive float",
+      "template": "{{ 5.4 | abs }}",
+      "result": "5.4",
+      "tags": [
+        "abs filter"
+      ]
+    },
+    {
+      "name": "filters, abs, positive integer",
+      "template": "{{ 5 | abs }}",
+      "result": "5",
+      "tags": [
+        "abs filter"
+      ]
+    },
+    {
+      "name": "filters, abs, positive string float",
+      "template": "{{ '5.1' | abs }}",
+      "result": "5.1",
+      "tags": [
+        "abs filter"
+      ]
+    },
+    {
+      "name": "filters, abs, positive string integer",
+      "template": "{{ '5' | abs }}",
+      "result": "5",
+      "tags": [
+        "abs filter"
+      ]
+    },
+    {
+      "name": "filters, abs, string not a number",
+      "template": "{{ 'hello' | abs }}",
+      "result": "0",
+      "tags": [
+        "abs filter"
+      ]
+    },
+    {
       "name": "filters, abs, undefined left value",
       "template": "{{ nosuchthing | abs }}",
       "result": "0",
@@ -1349,25 +1333,33 @@
       ]
     },
     {
-      "name": "filters, append, concat",
-      "template": "{{ \"hello\" | append: \"there\" }}",
-      "result": "hellothere",
+      "name": "filters, abs, unexpected argument",
+      "template": "{{ -3 | abs: 1 }}",
+      "invalid": true,
       "tags": [
-        "append filter"
+        "abs filter"
       ]
     },
     {
-      "name": "filters, append, not a string",
-      "template": "{{ 5 | append: 'there' }}",
-      "result": "5there",
+      "name": "filters, abs, zero",
+      "template": "{{ 0 | abs }}",
+      "result": "0",
       "tags": [
-        "append filter"
+        "abs filter"
       ]
     },
     {
       "name": "filters, append, argument not a string",
       "template": "{{ \"hello\" | append: 5 }}",
       "result": "hello5",
+      "tags": [
+        "append filter"
+      ]
+    },
+    {
+      "name": "filters, append, concat",
+      "template": "{{ \"hello\" | append: \"there\" }}",
+      "result": "hellothere",
       "tags": [
         "append filter"
       ]
@@ -1381,17 +1373,17 @@
       ]
     },
     {
-      "name": "filters, append, too many arguments",
-      "template": "{{ \"hello\" | append: \"how\", \"are\", \"you\" }}",
-      "invalid": true,
+      "name": "filters, append, not a string",
+      "template": "{{ 5 | append: 'there' }}",
+      "result": "5there",
       "tags": [
         "append filter"
       ]
     },
     {
-      "name": "filters, append, undefined left value",
-      "template": "{{ nosuchthing | append: \"hi\" }}",
-      "result": "hi",
+      "name": "filters, append, too many arguments",
+      "template": "{{ \"hello\" | append: \"how\", \"are\", \"you\" }}",
+      "invalid": true,
       "tags": [
         "append filter"
       ]
@@ -1405,17 +1397,41 @@
       ]
     },
     {
-      "name": "filters, at least, positive integer < arg",
-      "template": "{{ 5 | at_least: 8 }}",
-      "result": "8",
+      "name": "filters, append, undefined left value",
+      "template": "{{ nosuchthing | append: \"hi\" }}",
+      "result": "hi",
+      "tags": [
+        "append filter"
+      ]
+    },
+    {
+      "name": "filters, at least, argument string not a number",
+      "template": "{{ -1 | at_least: \"abc\" }}",
+      "result": "0",
       "tags": [
         "at_least filter"
       ]
     },
     {
-      "name": "filters, at least, positive integer > arg",
-      "template": "{{ 8 | at_least: 5 }}",
-      "result": "8",
+      "name": "filters, at least, left value not a number",
+      "template": "{{ \"abc\" | at_least: 2 }}",
+      "result": "2",
+      "tags": [
+        "at_least filter"
+      ]
+    },
+    {
+      "name": "filters, at least, left value not a number negative argument",
+      "template": "{{ \"abc\" | at_least: -2 }}",
+      "result": "0",
+      "tags": [
+        "at_least filter"
+      ]
+    },
+    {
+      "name": "filters, at least, missing arg",
+      "template": "{{ 5 | at_least }}",
+      "invalid": true,
       "tags": [
         "at_least filter"
       ]
@@ -1423,14 +1439,6 @@
     {
       "name": "filters, at least, negative integer < arg",
       "template": "{{ -8 | at_least: 5 }}",
-      "result": "5",
-      "tags": [
-        "at_least filter"
-      ]
-    },
-    {
-      "name": "filters, at least, positive integer == arg",
-      "template": "{{ 5 | at_least: 5 }}",
       "result": "5",
       "tags": [
         "at_least filter"
@@ -1453,17 +1461,33 @@
       ]
     },
     {
-      "name": "filters, at least, positive string > arg",
-      "template": "{{ \"9\" | at_least: 8 }}",
-      "result": "9",
+      "name": "filters, at least, positive integer < arg",
+      "template": "{{ 5 | at_least: 8 }}",
+      "result": "8",
       "tags": [
         "at_least filter"
       ]
     },
     {
-      "name": "filters, at least, missing arg",
-      "template": "{{ 5 | at_least }}",
-      "invalid": true,
+      "name": "filters, at least, positive integer == arg",
+      "template": "{{ 5 | at_least: 5 }}",
+      "result": "5",
+      "tags": [
+        "at_least filter"
+      ]
+    },
+    {
+      "name": "filters, at least, positive integer > arg",
+      "template": "{{ 8 | at_least: 5 }}",
+      "result": "8",
+      "tags": [
+        "at_least filter"
+      ]
+    },
+    {
+      "name": "filters, at least, positive string > arg",
+      "template": "{{ \"9\" | at_least: 8 }}",
+      "result": "9",
       "tags": [
         "at_least filter"
       ]
@@ -1477,14 +1501,6 @@
       ]
     },
     {
-      "name": "filters, at least, undefined left value",
-      "template": "{{ nosuchthing | at_least: 5 }}",
-      "result": "5",
-      "tags": [
-        "at_least filter"
-      ]
-    },
-    {
       "name": "filters, at least, undefined argument",
       "template": "{{ 5 | at_least: nosuchthing }}",
       "result": "5",
@@ -1493,41 +1509,25 @@
       ]
     },
     {
-      "name": "filters, at least, left value not a number",
-      "template": "{{ \"abc\" | at_least: 2 }}",
-      "result": "2",
-      "tags": [
-        "at_least filter"
-      ]
-    },
-    {
-      "name": "filters, at least, left value not a number negative argument",
-      "template": "{{ \"abc\" | at_least: -2 }}",
-      "result": "0",
-      "tags": [
-        "at_least filter"
-      ]
-    },
-    {
-      "name": "filters, at least, argument string not a number",
-      "template": "{{ -1 | at_least: \"abc\" }}",
-      "result": "0",
-      "tags": [
-        "at_least filter"
-      ]
-    },
-    {
-      "name": "filters, at most, positive integer < arg",
-      "template": "{{ 5 | at_most: 8 }}",
+      "name": "filters, at least, undefined left value",
+      "template": "{{ nosuchthing | at_least: 5 }}",
       "result": "5",
+      "tags": [
+        "at_least filter"
+      ]
+    },
+    {
+      "name": "filters, at most, left value not a number",
+      "template": "{{ \"abc\" | at_most: -2 }}",
+      "result": "-2",
       "tags": [
         "at_most filter"
       ]
     },
     {
-      "name": "filters, at most, positive integer > arg",
-      "template": "{{ 8 | at_most: 5 }}",
-      "result": "5",
+      "name": "filters, at most, missing arg",
+      "template": "{{ 5 | at_most }}",
+      "invalid": true,
       "tags": [
         "at_most filter"
       ]
@@ -1536,14 +1536,6 @@
       "name": "filters, at most, negative integer < arg",
       "template": "{{ -8 | at_most: 5 }}",
       "result": "-8",
-      "tags": [
-        "at_most filter"
-      ]
-    },
-    {
-      "name": "filters, at most, positive integer == arg",
-      "template": "{{ 5 | at_most: 5 }}",
-      "result": "5",
       "tags": [
         "at_most filter"
       ]
@@ -1565,17 +1557,33 @@
       ]
     },
     {
-      "name": "filters, at most, positive string > arg",
-      "template": "{{ \"9\" | at_most: 8 }}",
-      "result": "8",
+      "name": "filters, at most, positive integer < arg",
+      "template": "{{ 5 | at_most: 8 }}",
+      "result": "5",
       "tags": [
         "at_most filter"
       ]
     },
     {
-      "name": "filters, at most, missing arg",
-      "template": "{{ 5 | at_most }}",
-      "invalid": true,
+      "name": "filters, at most, positive integer == arg",
+      "template": "{{ 5 | at_most: 5 }}",
+      "result": "5",
+      "tags": [
+        "at_most filter"
+      ]
+    },
+    {
+      "name": "filters, at most, positive integer > arg",
+      "template": "{{ 8 | at_most: 5 }}",
+      "result": "5",
+      "tags": [
+        "at_most filter"
+      ]
+    },
+    {
+      "name": "filters, at most, positive string > arg",
+      "template": "{{ \"9\" | at_most: 8 }}",
+      "result": "8",
       "tags": [
         "at_most filter"
       ]
@@ -1589,14 +1597,6 @@
       ]
     },
     {
-      "name": "filters, at most, undefined left value",
-      "template": "{{ nosuchthing | at_most: 5 }}",
-      "result": "0",
-      "tags": [
-        "at_most filter"
-      ]
-    },
-    {
       "name": "filters, at most, undefined argument",
       "template": "{{ 5 | at_most: nosuchthing }}",
       "result": "0",
@@ -1605,9 +1605,9 @@
       ]
     },
     {
-      "name": "filters, at most, left value not a number",
-      "template": "{{ \"abc\" | at_most: -2 }}",
-      "result": "-2",
+      "name": "filters, at most, undefined left value",
+      "template": "{{ nosuchthing | at_most: 5 }}",
+      "result": "0",
       "tags": [
         "at_most filter"
       ]
@@ -1640,17 +1640,17 @@
       ]
     },
     {
-      "name": "filters, base64 decode, unexpected argument",
-      "template": "{{ \"hello\" | base64_decode: 5 }}",
-      "invalid": true,
+      "name": "filters, base64 decode, undefined left value",
+      "template": "{{ nosuchthing | base64_decode }}",
+      "result": "",
       "tags": [
         "base64_decode filter"
       ]
     },
     {
-      "name": "filters, base64 decode, undefined left value",
-      "template": "{{ nosuchthing | base64_decode }}",
-      "result": "",
+      "name": "filters, base64 decode, unexpected argument",
+      "template": "{{ \"hello\" | base64_decode: 5 }}",
+      "invalid": true,
       "tags": [
         "base64_decode filter"
       ]
@@ -1683,17 +1683,17 @@
       ]
     },
     {
-      "name": "filters, base64 encode, unexpected argument",
-      "template": "{{ \"hello\" | base64_encode: 5 }}",
-      "invalid": true,
+      "name": "filters, base64 encode, undefined left value",
+      "template": "{{ nosuchthing | base64_encode }}",
+      "result": "",
       "tags": [
         "base64_encode filter"
       ]
     },
     {
-      "name": "filters, base64 encode, undefined left value",
-      "template": "{{ nosuchthing | base64_encode }}",
-      "result": "",
+      "name": "filters, base64 encode, unexpected argument",
+      "template": "{{ \"hello\" | base64_encode: 5 }}",
+      "invalid": true,
       "tags": [
         "base64_encode filter"
       ]
@@ -1726,17 +1726,17 @@
       ]
     },
     {
-      "name": "filters, base64 url safe decode, unexpected argument",
-      "template": "{{ \"hello\" | base64_url_safe_decode: 5 }}",
-      "invalid": true,
+      "name": "filters, base64 url safe decode, undefined left value",
+      "template": "{{ nosuchthing | base64_url_safe_decode }}",
+      "result": "",
       "tags": [
         "base64_url_safe_decode filter"
       ]
     },
     {
-      "name": "filters, base64 url safe decode, undefined left value",
-      "template": "{{ nosuchthing | base64_url_safe_decode }}",
-      "result": "",
+      "name": "filters, base64 url safe decode, unexpected argument",
+      "template": "{{ \"hello\" | base64_url_safe_decode: 5 }}",
+      "invalid": true,
       "tags": [
         "base64_url_safe_decode filter"
       ]
@@ -1769,14 +1769,6 @@
       ]
     },
     {
-      "name": "filters, base64 url safe encode, unexpected argument",
-      "template": "{{ \"hello\" | base64_url_safe_encode: 5 }}",
-      "invalid": true,
-      "tags": [
-        "base64_url_safe_encode filter"
-      ]
-    },
-    {
       "name": "filters, base64 url safe encode, undefined left value",
       "template": "{{ nosuchthing | base64_url_safe_encode }}",
       "result": "",
@@ -1785,11 +1777,11 @@
       ]
     },
     {
-      "name": "filters, capitalize, lower case string",
-      "template": "{{ \"hello\" | capitalize }}",
-      "result": "Hello",
+      "name": "filters, base64 url safe encode, unexpected argument",
+      "template": "{{ \"hello\" | base64_url_safe_encode: 5 }}",
+      "invalid": true,
       "tags": [
-        "capitalize filter"
+        "base64_url_safe_encode filter"
       ]
     },
     {
@@ -1801,9 +1793,9 @@
       ]
     },
     {
-      "name": "filters, capitalize, unexpected argument",
-      "template": "{{ \"hello\" | capitalize: 2 }}",
-      "invalid": true,
+      "name": "filters, capitalize, lower case string",
+      "template": "{{ \"hello\" | capitalize }}",
+      "result": "Hello",
       "tags": [
         "capitalize filter"
       ]
@@ -1817,9 +1809,17 @@
       ]
     },
     {
-      "name": "filters, ceil, positive integer",
-      "template": "{{ 5 | ceil }}",
-      "result": "5",
+      "name": "filters, capitalize, unexpected argument",
+      "template": "{{ \"hello\" | capitalize: 2 }}",
+      "invalid": true,
+      "tags": [
+        "capitalize filter"
+      ]
+    },
+    {
+      "name": "filters, ceil, negative float",
+      "template": "{{ -5.4 | ceil }}",
+      "result": "-5",
       "tags": [
         "ceil filter"
       ]
@@ -1833,57 +1833,9 @@
       ]
     },
     {
-      "name": "filters, ceil, positive float",
-      "template": "{{ 5.4 | ceil }}",
-      "result": "6",
-      "tags": [
-        "ceil filter"
-      ]
-    },
-    {
-      "name": "filters, ceil, negative float",
-      "template": "{{ -5.4 | ceil }}",
-      "result": "-5",
-      "tags": [
-        "ceil filter"
-      ]
-    },
-    {
-      "name": "filters, ceil, zero",
-      "template": "{{ 0 | ceil }}",
-      "result": "0",
-      "tags": [
-        "ceil filter"
-      ]
-    },
-    {
-      "name": "filters, ceil, positive string float",
-      "template": "{{ \"5.1\" | ceil }}",
-      "result": "6",
-      "tags": [
-        "ceil filter"
-      ]
-    },
-    {
       "name": "filters, ceil, negative string float",
       "template": "{{ \"-5.1\" | ceil }}",
       "result": "-5",
-      "tags": [
-        "ceil filter"
-      ]
-    },
-    {
-      "name": "filters, ceil, unexpected argument",
-      "template": "{{ -3.1 | ceil: 1 }}",
-      "invalid": true,
-      "tags": [
-        "ceil filter"
-      ]
-    },
-    {
-      "name": "filters, ceil, string not a number",
-      "template": "{{ \"hello\" | ceil }}",
-      "result": "0",
       "tags": [
         "ceil filter"
       ]
@@ -1900,11 +1852,85 @@
       ]
     },
     {
+      "name": "filters, ceil, positive float",
+      "template": "{{ 5.4 | ceil }}",
+      "result": "6",
+      "tags": [
+        "ceil filter"
+      ]
+    },
+    {
+      "name": "filters, ceil, positive integer",
+      "template": "{{ 5 | ceil }}",
+      "result": "5",
+      "tags": [
+        "ceil filter"
+      ]
+    },
+    {
+      "name": "filters, ceil, positive string float",
+      "template": "{{ \"5.1\" | ceil }}",
+      "result": "6",
+      "tags": [
+        "ceil filter"
+      ]
+    },
+    {
+      "name": "filters, ceil, string not a number",
+      "template": "{{ \"hello\" | ceil }}",
+      "result": "0",
+      "tags": [
+        "ceil filter"
+      ]
+    },
+    {
       "name": "filters, ceil, undefined left value",
       "template": "{{ nosuchthing | ceil }}",
       "result": "0",
       "tags": [
         "ceil filter"
+      ]
+    },
+    {
+      "name": "filters, ceil, unexpected argument",
+      "template": "{{ -3.1 | ceil: 1 }}",
+      "invalid": true,
+      "tags": [
+        "ceil filter"
+      ]
+    },
+    {
+      "name": "filters, ceil, zero",
+      "template": "{{ 0 | ceil }}",
+      "result": "0",
+      "tags": [
+        "ceil filter"
+      ]
+    },
+    {
+      "name": "filters, compact, array of objects with key property",
+      "template": "{% assign x = a | compact: 'title' %}{% for obj in x %}{% for i in obj %}({{ i[0] }},{{ i[1] }}){% endfor %}{% endfor %}",
+      "data": {
+        "a": [
+          {
+            "title": "foo",
+            "name": "a"
+          },
+          {
+            "title": null,
+            "name": "b"
+          },
+          {
+            "title": "bar",
+            "name": "c"
+          }
+        ]
+      },
+      "result": "(title,foo)(name,a)(title,bar)(name,c)",
+      "tags": [
+        "assign tag",
+        "compact filter",
+        "for tag"
       ]
     },
     {
@@ -1937,14 +1963,6 @@
       ]
     },
     {
-      "name": "filters, compact, too many arguments",
-      "template": "{{ a | compact: 'foo', 'bar' }}",
-      "invalid": true,
-      "tags": [
-        "compact filter"
-      ]
-    },
-    {
       "name": "filters, compact, left value is not an array",
       "template": "{{ a | compact | first }}",
       "data": {
@@ -1965,111 +1983,11 @@
       ]
     },
     {
-      "name": "filters, compact, array of objects with key property",
-      "template": "{% assign x = a | compact: 'title' %}{% for obj in x %}{% for i in obj %}({{ i[0] }},{{ i[1] }}){% endfor %}{% endfor %}",
-      "data": {
-        "a": [
-          {
-            "title": "foo",
-            "name": "a"
-          },
-          {
-            "title": null,
-            "name": "b"
-          },
-          {
-            "title": "bar",
-            "name": "c"
-          }
-        ]
-      },
-      "result": "(title,foo)(name,a)(title,bar)(name,c)",
-      "tags": [
-        "assign tag",
-        "compact filter",
-        "for tag"
-      ]
-    },
-    {
-      "name": "filters, concat, range literal concat filter left value",
-      "template": "{{ (1..3) | concat: foo | join: '#' }}",
-      "data": {
-        "foo": [
-          5,
-          6,
-          7
-        ]
-      },
-      "result": "1#2#3#5#6#7",
-      "tags": [
-        "concat filter",
-        "join filter"
-      ]
-    },
-    {
-      "name": "filters, concat, two arrays of strings",
-      "template": "{{ a | concat: b | join: '#' }}",
-      "data": {
-        "a": [
-          "a",
-          "b"
-        ],
-        "b": [
-          "c",
-          "d"
-        ]
-      },
-      "result": "a#b#c#d",
-      "tags": [
-        "concat filter",
-        "join filter"
-      ]
-    },
-    {
-      "name": "filters, concat, missing argument is an error",
-      "template": "{{ a | concat | join: '#' }}",
-      "data": {
-        "a": [
-          "a",
-          "b"
-        ]
-      },
+      "name": "filters, compact, too many arguments",
+      "template": "{{ a | compact: 'foo', 'bar' }}",
       "invalid": true,
       "tags": [
-        "concat filter",
-        "join filter"
-      ]
-    },
-    {
-      "name": "filters, concat, non array-like argument is an error",
-      "template": "{{ a | concat: b | join: '#' }}",
-      "data": {
-        "a": [
-          "a",
-          "b"
-        ],
-        "b": 5
-      },
-      "invalid": true,
-      "tags": [
-        "concat filter",
-        "join filter"
-      ]
-    },
-    {
-      "name": "filters, concat, left value is not array-like",
-      "template": "{{ a | concat: b | join: '#' }}",
-      "data": {
-        "a": "ab",
-        "b": [
-          "c",
-          "d"
-        ]
-      },
-      "result": "ab#c#d",
-      "tags": [
-        "concat filter",
-        "join filter"
+        "compact filter"
       ]
     },
     {
@@ -2093,23 +2011,24 @@
       ]
     },
     {
-      "name": "filters, concat, undefined left value",
-      "template": "{{ nosuchthing | concat: b | join: '#' }}",
+      "name": "filters, concat, left value is not array-like",
+      "template": "{{ a | concat: b | join: '#' }}",
       "data": {
+        "a": "ab",
         "b": [
           "c",
           "d"
         ]
       },
-      "result": "c#d",
+      "result": "ab#c#d",
       "tags": [
         "concat filter",
         "join filter"
       ]
     },
     {
-      "name": "filters, concat, undefined argument is an error",
-      "template": "{{ a | concat: nosuchthing | join: '#' }}",
+      "name": "filters, concat, missing argument is an error",
+      "template": "{{ a | concat | join: '#' }}",
       "data": {
         "a": [
           "a",
@@ -2153,43 +2072,84 @@
       ]
     },
     {
-      "name": "filters, date, well formed string",
-      "template": "{{ 'March 14, 2016' | date: '%b %d, %y' }}",
-      "result": "Mar 14, 16",
-      "tags": [
-        "date filter"
-      ]
-    },
-    {
-      "name": "filters, date, too many arguments",
-      "template": "{{ 'March 14, 2016' | date: '%b %d, %y', 'foo' }}",
+      "name": "filters, concat, non array-like argument is an error",
+      "template": "{{ a | concat: b | join: '#' }}",
+      "data": {
+        "a": [
+          "a",
+          "b"
+        ],
+        "b": 5
+      },
       "invalid": true,
       "tags": [
-        "date filter"
+        "concat filter",
+        "join filter"
       ]
     },
     {
-      "name": "filters, date, undefined left value",
-      "template": "{{ nosuchthing | date: '%b %d, %y' }}",
-      "result": "",
+      "name": "filters, concat, range literal concat filter left value",
+      "template": "{{ (1..3) | concat: foo | join: '#' }}",
+      "data": {
+        "foo": [
+          5,
+          6,
+          7
+        ]
+      },
+      "result": "1#2#3#5#6#7",
       "tags": [
-        "date filter"
+        "concat filter",
+        "join filter"
       ]
     },
     {
-      "name": "filters, date, missing argument",
-      "template": "{{ 'March 14, 2016' | date }}",
+      "name": "filters, concat, two arrays of strings",
+      "template": "{{ a | concat: b | join: '#' }}",
+      "data": {
+        "a": [
+          "a",
+          "b"
+        ],
+        "b": [
+          "c",
+          "d"
+        ]
+      },
+      "result": "a#b#c#d",
+      "tags": [
+        "concat filter",
+        "join filter"
+      ]
+    },
+    {
+      "name": "filters, concat, undefined argument is an error",
+      "template": "{{ a | concat: nosuchthing | join: '#' }}",
+      "data": {
+        "a": [
+          "a",
+          "b"
+        ]
+      },
       "invalid": true,
       "tags": [
-        "date filter"
+        "concat filter",
+        "join filter"
       ]
     },
     {
-      "name": "filters, date, undefined argument",
-      "template": "{{ 'March 14, 2016' | date: nosuchthing }}",
-      "result": "March 14, 2016",
+      "name": "filters, concat, undefined left value",
+      "template": "{{ nosuchthing | concat: b | join: '#' }}",
+      "data": {
+        "b": [
+          "c",
+          "d"
+        ]
+      },
+      "result": "c#d",
       "tags": [
-        "date filter"
+        "concat filter",
+        "join filter"
       ]
     },
     {
@@ -2201,17 +2161,9 @@
       ]
     },
     {
-      "name": "filters, date, timestamp integer",
-      "template": "{{ 1152098955 | date: '%m/%d/%Y' }}",
-      "result": "07/05/2006",
-      "tags": [
-        "date filter"
-      ]
-    },
-    {
-      "name": "filters, date, timestamp string",
-      "template": "{{ '1152098955' | date: '%m/%d/%Y' }}",
-      "result": "07/05/2006",
+      "name": "filters, date, missing argument",
+      "template": "{{ 'March 14, 2016' | date }}",
+      "invalid": true,
       "tags": [
         "date filter"
       ]
@@ -2233,25 +2185,84 @@
       ]
     },
     {
-      "name": "filters, default, nil",
-      "template": "{{ nil | default: 'foo' }}",
-      "result": "foo",
+      "name": "filters, date, timestamp integer",
+      "template": "{{ 1152098955 | date: '%m/%d/%Y' }}",
+      "result": "07/05/2006",
+      "tags": [
+        "date filter"
+      ]
+    },
+    {
+      "name": "filters, date, timestamp string",
+      "template": "{{ '1152098955' | date: '%m/%d/%Y' }}",
+      "result": "07/05/2006",
+      "tags": [
+        "date filter"
+      ]
+    },
+    {
+      "name": "filters, date, too many arguments",
+      "template": "{{ 'March 14, 2016' | date: '%b %d, %y', 'foo' }}",
+      "invalid": true,
+      "tags": [
+        "date filter"
+      ]
+    },
+    {
+      "name": "filters, date, undefined argument",
+      "template": "{{ 'March 14, 2016' | date: nosuchthing }}",
+      "result": "March 14, 2016",
+      "tags": [
+        "date filter"
+      ]
+    },
+    {
+      "name": "filters, date, undefined left value",
+      "template": "{{ nosuchthing | date: '%b %d, %y' }}",
+      "result": "",
+      "tags": [
+        "date filter"
+      ]
+    },
+    {
+      "name": "filters, date, well formed string",
+      "template": "{{ 'March 14, 2016' | date: '%b %d, %y' }}",
+      "result": "Mar 14, 16",
+      "tags": [
+        "date filter"
+      ]
+    },
+    {
+      "name": "filters, default, 0.0 is not falsy",
+      "template": "{{ 0.0 | default: \"bar\" }}",
+      "result": "0.0",
       "tags": [
         "default filter"
       ]
     },
     {
-      "name": "filters, default, false",
-      "template": "{{ False | default: 'foo' }}",
-      "result": "foo",
+      "name": "filters, default, allow false",
+      "template": "{{ false | default: 'bar', allow_false:true }}",
+      "result": "false",
       "tags": [
         "default filter"
       ]
     },
     {
-      "name": "filters, default, empty string",
-      "template": "{{ \"\" | default: \"foo\" }}",
-      "result": "foo",
+      "name": "filters, default, allow false from context",
+      "template": "{{ false | default: 'bar', allow_false:foo }}",
+      "data": {
+        "foo": true
+      },
+      "result": "false",
+      "tags": [
+        "default filter"
+      ]
+    },
+    {
+      "name": "filters, default, empty",
+      "template": "{{ empty | default: bar }}",
+      "result": "",
       "tags": [
         "default filter"
       ]
@@ -2279,9 +2290,41 @@
       ]
     },
     {
-      "name": "filters, default, not empty string",
-      "template": "{{ \"hello\" | default: \"foo\" }}",
-      "result": "hello",
+      "name": "filters, default, empty string",
+      "template": "{{ \"\" | default: \"foo\" }}",
+      "result": "foo",
+      "tags": [
+        "default filter"
+      ]
+    },
+    {
+      "name": "filters, default, false",
+      "template": "{{ False | default: 'foo' }}",
+      "result": "foo",
+      "tags": [
+        "default filter"
+      ]
+    },
+    {
+      "name": "filters, default, false keyword argument before positional",
+      "template": "{{ false | default: allow_false: false, \"bar\" }}",
+      "result": "bar",
+      "tags": [
+        "default filter"
+      ]
+    },
+    {
+      "name": "filters, default, missing argument",
+      "template": "{{ false | default }}",
+      "result": "",
+      "tags": [
+        "default filter"
+      ]
+    },
+    {
+      "name": "filters, default, nil",
+      "template": "{{ nil | default: 'foo' }}",
+      "result": "foo",
       "tags": [
         "default filter"
       ]
@@ -2320,52 +2363,17 @@
       ]
     },
     {
+      "name": "filters, default, not empty string",
+      "template": "{{ \"hello\" | default: \"foo\" }}",
+      "result": "hello",
+      "tags": [
+        "default filter"
+      ]
+    },
+    {
       "name": "filters, default, too many arguments",
       "template": "{{ None | default: 'foo', 'bar', 'baz' }}",
       "invalid": true,
-      "tags": [
-        "default filter"
-      ]
-    },
-    {
-      "name": "filters, default, missing argument",
-      "template": "{{ false | default }}",
-      "result": "",
-      "tags": [
-        "default filter"
-      ]
-    },
-    {
-      "name": "filters, default, empty",
-      "template": "{{ empty | default: bar }}",
-      "result": "",
-      "tags": [
-        "default filter"
-      ]
-    },
-    {
-      "name": "filters, default, allow false",
-      "template": "{{ false | default: 'bar', allow_false:true }}",
-      "result": "false",
-      "tags": [
-        "default filter"
-      ]
-    },
-    {
-      "name": "filters, default, allow false from context",
-      "template": "{{ false | default: 'bar', allow_false:foo }}",
-      "data": {
-        "foo": true
-      },
-      "result": "false",
-      "tags": [
-        "default filter"
-      ]
-    },
-    {
-      "name": "filters, default, undefined left value",
-      "template": "{{ nosuchthing | default: \"bar\" }}",
-      "result": "bar",
       "tags": [
         "default filter"
       ]
@@ -2379,8 +2387,8 @@
       ]
     },
     {
-      "name": "filters, default, false keyword argument before positional",
-      "template": "{{ false | default: allow_false: false, \"bar\" }}",
+      "name": "filters, default, undefined left value",
+      "template": "{{ nosuchthing | default: \"bar\" }}",
       "result": "bar",
       "tags": [
         "default filter"
@@ -2403,41 +2411,17 @@
       ]
     },
     {
-      "name": "filters, default, 0.0 is not falsy",
-      "template": "{{ 0.0 | default: \"bar\" }}",
-      "result": "0.0",
-      "tags": [
-        "default filter"
-      ]
-    },
-    {
-      "name": "filters, divided by, integer value and integer arg",
-      "template": "{{ 10 | divided_by: 2 }}",
-      "result": "5",
+      "name": "filters, divided by, arg string not a number",
+      "template": "{{ \"10\" | divided_by: \"foo\" }}",
+      "invalid": true,
       "tags": [
         "divided_by filter"
       ]
     },
     {
-      "name": "filters, divided by, integer value and float arg",
-      "template": "{{ 10 | divided_by: 2.0 }}",
-      "result": "5.0",
-      "tags": [
-        "divided_by filter"
-      ]
-    },
-    {
-      "name": "filters, divided by, integer division",
-      "template": "{{ 9 | divided_by: 2 }}",
-      "result": "4",
-      "tags": [
-        "divided_by filter"
-      ]
-    },
-    {
-      "name": "filters, divided by, float value and integer arg",
-      "template": "{{ 9.0 | divided_by: 2 }}",
-      "result": "4.5",
+      "name": "filters, divided by, divied by zero",
+      "template": "{{ 10 | divided_by: 0 }}",
+      "invalid": true,
       "tags": [
         "divided_by filter"
       ]
@@ -2451,33 +2435,49 @@
       ]
     },
     {
-      "name": "filters, divided by, string value and argument",
-      "template": "{{ \"10\" | divided_by: \"2\" }}",
+      "name": "filters, divided by, float value and integer arg",
+      "template": "{{ 9.0 | divided_by: 2 }}",
+      "result": "4.5",
+      "tags": [
+        "divided_by filter"
+      ]
+    },
+    {
+      "name": "filters, divided by, integer division",
+      "template": "{{ 9 | divided_by: 2 }}",
+      "result": "4",
+      "tags": [
+        "divided_by filter"
+      ]
+    },
+    {
+      "name": "filters, divided by, integer value and float arg",
+      "template": "{{ 10 | divided_by: 2.0 }}",
+      "result": "5.0",
+      "tags": [
+        "divided_by filter"
+      ]
+    },
+    {
+      "name": "filters, divided by, integer value and integer arg",
+      "template": "{{ 10 | divided_by: 2 }}",
       "result": "5",
       "tags": [
         "divided_by filter"
       ]
     },
     {
-      "name": "filters, divided by, string not a number",
-      "template": "{{ \"foo\" | divided_by: \"2\" }}",
+      "name": "filters, divided by, issue",
+      "template": "{{ 5 | divided_by: 3 }}",
+      "result": "1",
+      "tags": [
+        "divided_by filter"
+      ]
+    },
+    {
+      "name": "filters, divided by, left value is an empty string",
+      "template": "{{ '' | divided_by: 2 }}",
       "result": "0",
-      "tags": [
-        "divided_by filter"
-      ]
-    },
-    {
-      "name": "filters, divided by, arg string not a number",
-      "template": "{{ \"10\" | divided_by: \"foo\" }}",
-      "invalid": true,
-      "tags": [
-        "divided_by filter"
-      ]
-    },
-    {
-      "name": "filters, divided by, too many args",
-      "template": "{{ 5 | divided_by: 1, '5' }}",
-      "invalid": true,
       "tags": [
         "divided_by filter"
       ]
@@ -2494,9 +2494,30 @@
       ]
     },
     {
-      "name": "filters, divided by, undefined left value",
-      "template": "{{ nosuchthing | divided_by: 2 }}",
+      "name": "filters, divided by, render",
+      "template": "{{ 5.0 }} {{ 5 }}",
+      "result": "5.0 5"
+    },
+    {
+      "name": "filters, divided by, string not a number",
+      "template": "{{ \"foo\" | divided_by: \"2\" }}",
       "result": "0",
+      "tags": [
+        "divided_by filter"
+      ]
+    },
+    {
+      "name": "filters, divided by, string value and argument",
+      "template": "{{ \"10\" | divided_by: \"2\" }}",
+      "result": "5",
+      "tags": [
+        "divided_by filter"
+      ]
+    },
+    {
+      "name": "filters, divided by, too many args",
+      "template": "{{ 5 | divided_by: 1, '5' }}",
+      "invalid": true,
       "tags": [
         "divided_by filter"
       ]
@@ -2510,9 +2531,9 @@
       ]
     },
     {
-      "name": "filters, divided by, divied by zero",
-      "template": "{{ 10 | divided_by: 0 }}",
-      "invalid": true,
+      "name": "filters, divided by, undefined left value",
+      "template": "{{ nosuchthing | divided_by: 2 }}",
+      "result": "0",
       "tags": [
         "divided_by filter"
       ]
@@ -2528,27 +2549,6 @@
     {
       "name": "filters, divided by, zero divided by integer",
       "template": "{{ 0 | divided_by: 1 }}",
-      "result": "0",
-      "tags": [
-        "divided_by filter"
-      ]
-    },
-    {
-      "name": "filters, divided by, issue",
-      "template": "{{ 5 | divided_by: 3 }}",
-      "result": "1",
-      "tags": [
-        "divided_by filter"
-      ]
-    },
-    {
-      "name": "filters, divided by, render",
-      "template": "{{ 5.0 }} {{ 5 }}",
-      "result": "5.0 5"
-    },
-    {
-      "name": "filters, divided by, left value is an empty string",
-      "template": "{{ '' | divided_by: 2 }}",
       "result": "0",
       "tags": [
         "divided_by filter"
@@ -2571,17 +2571,17 @@
       ]
     },
     {
-      "name": "filters, downcase, unexpected argument",
-      "template": "{{ \"HELLO\" | downcase: 5 }}",
-      "invalid": true,
+      "name": "filters, downcase, undefined left value",
+      "template": "{{ nosuchthing | downcase }}",
+      "result": "",
       "tags": [
         "downcase filter"
       ]
     },
     {
-      "name": "filters, downcase, undefined left value",
-      "template": "{{ nosuchthing | downcase }}",
-      "result": "",
+      "name": "filters, downcase, unexpected argument",
+      "template": "{{ \"HELLO\" | downcase: 5 }}",
+      "invalid": true,
       "tags": [
         "downcase filter"
       ]
@@ -2603,17 +2603,17 @@
       ]
     },
     {
-      "name": "filters, escape, unexpected argument",
-      "template": "{{ \"HELLO\" | escape: 5 }}",
-      "invalid": true,
+      "name": "filters, escape, undefined left value",
+      "template": "{{ nosuchthing | escape }}",
+      "result": "",
       "tags": [
         "escape filter"
       ]
     },
     {
-      "name": "filters, escape, undefined left value",
-      "template": "{{ nosuchthing | escape }}",
-      "result": "",
+      "name": "filters, escape, unexpected argument",
+      "template": "{{ \"HELLO\" | escape: 5 }}",
+      "invalid": true,
       "tags": [
         "escape filter"
       ]
@@ -2643,6 +2643,14 @@
       ]
     },
     {
+      "name": "filters, escape once, undefined left value",
+      "template": "{{ nosuchthing | escape_once }}",
+      "result": "",
+      "tags": [
+        "escape_once filter"
+      ]
+    },
+    {
       "name": "filters, escape once, unexpected argument",
       "template": "{{ \"HELLO\" | escape_once: 5 }}",
       "invalid": true,
@@ -2651,11 +2659,44 @@
       ]
     },
     {
-      "name": "filters, escape once, undefined left value",
-      "template": "{{ nosuchthing | escape_once }}",
+      "name": "filters, find, array of hashes, int value, match",
+      "template": "{% assign b = a | find: 'z', 42 %}{{ b.foo }}",
+      "data": {
+        "a": [
+          {
+            "x": 99
+          },
+          {
+            "z": 42,
+            "foo": "bar"
+          }
+        ]
+      },
+      "result": "bar",
+      "tags": [
+        "assign tag",
+        "find filter"
+      ]
+    },
+    {
+      "name": "filters, find, array of hashes, with a nil",
+      "template": "{% assign b = a | find: 'z', 42 %}{{ b.foo }}",
+      "data": {
+        "a": [
+          {
+            "x": 99
+          },
+          null,
+          {
+            "z": 42,
+            "foo": "bar"
+          }
+        ]
+      },
       "result": "",
       "tags": [
-        "escape_once filter"
+        "assign tag",
+        "find filter"
       ]
     },
     {
@@ -2669,6 +2710,21 @@
         ]
       },
       "result": "z",
+      "tags": [
+        "find filter"
+      ]
+    },
+    {
+      "name": "filters, find, array of strings, default value, no match",
+      "template": "{{ a | find: 'foo' }}",
+      "data": {
+        "a": [
+          "x",
+          "y",
+          "zoo"
+        ]
+      },
+      "result": "",
       "tags": [
         "find filter"
       ]
@@ -2689,17 +2745,58 @@
       ]
     },
     {
-      "name": "filters, find, array of strings, default value, no match",
-      "template": "{{ a | find: 'foo' }}",
+      "name": "filters, find, hash input, default value, match",
+      "template": "{% assign b = a | find: 'z' %}{{ b.z }}",
       "data": {
-        "a": [
-          "x",
-          "y",
-          "zoo"
-        ]
+        "a": {
+          "z": 42
+        }
+      },
+      "result": "42",
+      "tags": [
+        "assign tag",
+        "find filter"
+      ]
+    },
+    {
+      "name": "filters, find, hash input, default value, no match",
+      "template": "{% assign b = a | find: 'foo' %}{{ b }}",
+      "data": {
+        "a": {
+          "z": 42
+        }
       },
       "result": "",
       "tags": [
+        "assign tag",
+        "find filter"
+      ]
+    },
+    {
+      "name": "filters, find, hash input, explicit nil, match",
+      "template": "{% assign b = a | find: 'z', nil %}{{ b.z }}",
+      "data": {
+        "a": {
+          "z": null
+        }
+      },
+      "result": "",
+      "tags": [
+        "assign tag",
+        "find filter"
+      ]
+    },
+    {
+      "name": "filters, find, hash input, int value, match",
+      "template": "{% assign b = a | find: 'z', 42 %}{{ b.z }}",
+      "data": {
+        "a": {
+          "z": 42
+        }
+      },
+      "result": "42",
+      "tags": [
+        "assign tag",
         "find filter"
       ]
     },
@@ -2751,250 +2848,6 @@
       "result": "",
       "tags": [
         "find filter"
-      ]
-    },
-    {
-      "name": "filters, find, hash input, default value, match",
-      "template": "{% assign b = a | find: 'z' %}{{ b.z }}",
-      "data": {
-        "a": {
-          "z": 42
-        }
-      },
-      "result": "42",
-      "tags": [
-        "assign tag",
-        "find filter"
-      ]
-    },
-    {
-      "name": "filters, find, hash input, default value, no match",
-      "template": "{% assign b = a | find: 'foo' %}{{ b }}",
-      "data": {
-        "a": {
-          "z": 42
-        }
-      },
-      "result": "",
-      "tags": [
-        "assign tag",
-        "find filter"
-      ]
-    },
-    {
-      "name": "filters, find, hash input, int value, match",
-      "template": "{% assign b = a | find: 'z', 42 %}{{ b.z }}",
-      "data": {
-        "a": {
-          "z": 42
-        }
-      },
-      "result": "42",
-      "tags": [
-        "assign tag",
-        "find filter"
-      ]
-    },
-    {
-      "name": "filters, find, hash input, explicit nil, match",
-      "template": "{% assign b = a | find: 'z', nil %}{{ b.z }}",
-      "data": {
-        "a": {
-          "z": null
-        }
-      },
-      "result": "",
-      "tags": [
-        "assign tag",
-        "find filter"
-      ]
-    },
-    {
-      "name": "filters, find, array of hashes, int value, match",
-      "template": "{% assign b = a | find: 'z', 42 %}{{ b.foo }}",
-      "data": {
-        "a": [
-          {
-            "x": 99
-          },
-          {
-            "z": 42,
-            "foo": "bar"
-          }
-        ]
-      },
-      "result": "bar",
-      "tags": [
-        "assign tag",
-        "find filter"
-      ]
-    },
-    {
-      "name": "filters, find, array of hashes, with a nil",
-      "template": "{% assign b = a | find: 'z', 42 %}{{ b.foo }}",
-      "data": {
-        "a": [
-          {
-            "x": 99
-          },
-          null,
-          {
-            "z": 42,
-            "foo": "bar"
-          }
-        ]
-      },
-      "result": "",
-      "tags": [
-        "assign tag",
-        "find filter"
-      ]
-    },
-    {
-      "name": "filters, find index, array of strings, default value",
-      "template": "{{ a | find_index: 'z' }}",
-      "data": {
-        "a": [
-          "x",
-          "y",
-          "z"
-        ]
-      },
-      "result": "2",
-      "tags": [
-        "find_index filter"
-      ]
-    },
-    {
-      "name": "filters, find index, array of strings, substring match, default value",
-      "template": "{{ a | find_index: 'oo' }}",
-      "data": {
-        "a": [
-          "x",
-          "y",
-          "zoo"
-        ]
-      },
-      "result": "2",
-      "tags": [
-        "find_index filter"
-      ]
-    },
-    {
-      "name": "filters, find index, array of strings, default value, no match",
-      "template": "{{ a | find_index: 'foo' }}",
-      "data": {
-        "a": [
-          "x",
-          "y",
-          "zoo"
-        ]
-      },
-      "result": "",
-      "tags": [
-        "find_index filter"
-      ]
-    },
-    {
-      "name": "filters, find index, mixed array, default value",
-      "template": "{{ a | find_index: 'z' }}",
-      "data": {
-        "a": [
-          "x",
-          null,
-          "z",
-          false,
-          true
-        ]
-      },
-      "result": "",
-      "tags": [
-        "find_index filter"
-      ]
-    },
-    {
-      "name": "filters, find index, string input, default value, match",
-      "template": "{{ a | find_index: 'z' }}",
-      "data": {
-        "a": "zoo"
-      },
-      "result": "0",
-      "tags": [
-        "find_index filter"
-      ]
-    },
-    {
-      "name": "filters, find index, string input, string value, match",
-      "template": "{{ a | find_index: 'z', 'z' }}",
-      "data": {
-        "a": "zoo"
-      },
-      "result": "0",
-      "tags": [
-        "find_index filter"
-      ]
-    },
-    {
-      "name": "filters, find index, string input, string value, no match",
-      "template": "{{ a | find_index: 'z', 'y' }}",
-      "data": {
-        "a": "zoo"
-      },
-      "result": "",
-      "tags": [
-        "find_index filter"
-      ]
-    },
-    {
-      "name": "filters, find index, hash input, default value, match",
-      "template": "{{ a | find_index: 'z' }}",
-      "data": {
-        "a": {
-          "z": 42
-        }
-      },
-      "result": "0",
-      "tags": [
-        "find_index filter"
-      ]
-    },
-    {
-      "name": "filters, find index, hash input, default value, no match",
-      "template": "{{ a | find_index: 'foo' }}",
-      "data": {
-        "a": {
-          "z": 42
-        }
-      },
-      "result": "",
-      "tags": [
-        "find_index filter"
-      ]
-    },
-    {
-      "name": "filters, find index, hash input, int value, match",
-      "template": "{{ a | find_index: 'z', 42 }}",
-      "data": {
-        "a": {
-          "z": 42
-        }
-      },
-      "result": "0",
-      "tags": [
-        "find_index filter"
-      ]
-    },
-    {
-      "name": "filters, find index, hash input, explicit nil, match",
-      "template": "{{ a | find_index: 'z', nil }}",
-      "data": {
-        "a": {
-          "z": null
-        }
-      },
-      "result": "",
-      "tags": [
-        "find_index filter"
       ]
     },
     {
@@ -3055,11 +2908,150 @@
       ]
     },
     {
-      "name": "filters, first, range literal first filter left value",
-      "template": "{{ (1..3) | first }}",
-      "result": "1",
+      "name": "filters, find index, array of strings, default value",
+      "template": "{{ a | find_index: 'z' }}",
+      "data": {
+        "a": [
+          "x",
+          "y",
+          "z"
+        ]
+      },
+      "result": "2",
       "tags": [
-        "first filter"
+        "find_index filter"
+      ]
+    },
+    {
+      "name": "filters, find index, array of strings, default value, no match",
+      "template": "{{ a | find_index: 'foo' }}",
+      "data": {
+        "a": [
+          "x",
+          "y",
+          "zoo"
+        ]
+      },
+      "result": "",
+      "tags": [
+        "find_index filter"
+      ]
+    },
+    {
+      "name": "filters, find index, array of strings, substring match, default value",
+      "template": "{{ a | find_index: 'oo' }}",
+      "data": {
+        "a": [
+          "x",
+          "y",
+          "zoo"
+        ]
+      },
+      "result": "2",
+      "tags": [
+        "find_index filter"
+      ]
+    },
+    {
+      "name": "filters, find index, hash input, default value, match",
+      "template": "{{ a | find_index: 'z' }}",
+      "data": {
+        "a": {
+          "z": 42
+        }
+      },
+      "result": "0",
+      "tags": [
+        "find_index filter"
+      ]
+    },
+    {
+      "name": "filters, find index, hash input, default value, no match",
+      "template": "{{ a | find_index: 'foo' }}",
+      "data": {
+        "a": {
+          "z": 42
+        }
+      },
+      "result": "",
+      "tags": [
+        "find_index filter"
+      ]
+    },
+    {
+      "name": "filters, find index, hash input, explicit nil, match",
+      "template": "{{ a | find_index: 'z', nil }}",
+      "data": {
+        "a": {
+          "z": null
+        }
+      },
+      "result": "",
+      "tags": [
+        "find_index filter"
+      ]
+    },
+    {
+      "name": "filters, find index, hash input, int value, match",
+      "template": "{{ a | find_index: 'z', 42 }}",
+      "data": {
+        "a": {
+          "z": 42
+        }
+      },
+      "result": "0",
+      "tags": [
+        "find_index filter"
+      ]
+    },
+    {
+      "name": "filters, find index, mixed array, default value",
+      "template": "{{ a | find_index: 'z' }}",
+      "data": {
+        "a": [
+          "x",
+          null,
+          "z",
+          false,
+          true
+        ]
+      },
+      "result": "",
+      "tags": [
+        "find_index filter"
+      ]
+    },
+    {
+      "name": "filters, find index, string input, default value, match",
+      "template": "{{ a | find_index: 'z' }}",
+      "data": {
+        "a": "zoo"
+      },
+      "result": "0",
+      "tags": [
+        "find_index filter"
+      ]
+    },
+    {
+      "name": "filters, find index, string input, string value, match",
+      "template": "{{ a | find_index: 'z', 'z' }}",
+      "data": {
+        "a": "zoo"
+      },
+      "result": "0",
+      "tags": [
+        "find_index filter"
+      ]
+    },
+    {
+      "name": "filters, find index, string input, string value, no match",
+      "template": "{{ a | find_index: 'z', 'y' }}",
+      "data": {
+        "a": "zoo"
+      },
+      "result": "",
+      "tags": [
+        "find_index filter"
       ]
     },
     {
@@ -3105,6 +3097,32 @@
       ]
     },
     {
+      "name": "filters, first, first of a hash",
+      "template": "{% assign x = a | first %}({{ x[0] }},{{ x[1] }})",
+      "data": {
+        "a": {
+          "b": 1,
+          "c": 2
+        }
+      },
+      "result": "(b,1)",
+      "tags": [
+        "assign tag",
+        "first filter"
+      ]
+    },
+    {
+      "name": "filters, first, first of a string",
+      "template": "{{ 'hello' | first }}",
+      "results": [
+        "",
+        "h"
+      ],
+      "tags": [
+        "first filter"
+      ]
+    },
+    {
       "name": "filters, first, left value is not an array",
       "template": "{{ arr | first }}",
       "data": {
@@ -3124,35 +3142,17 @@
       ]
     },
     {
-      "name": "filters, first, first of a string",
-      "template": "{{ 'hello' | first }}",
-      "results": [
-        "",
-        "h"
-      ],
+      "name": "filters, first, range literal first filter left value",
+      "template": "{{ (1..3) | first }}",
+      "result": "1",
       "tags": [
         "first filter"
       ]
     },
     {
-      "name": "filters, first, first of a hash",
-      "template": "{% assign x = a | first %}({{ x[0] }},{{ x[1] }})",
-      "data": {
-        "a": {
-          "b": 1,
-          "c": 2
-        }
-      },
-      "result": "(b,1)",
-      "tags": [
-        "assign tag",
-        "first filter"
-      ]
-    },
-    {
-      "name": "filters, floor, positive integer",
-      "template": "{{ 5 | floor }}",
-      "result": "5",
+      "name": "filters, floor, negative float",
+      "template": "{{ -5.4 | floor }}",
+      "result": "-6",
       "tags": [
         "floor filter"
       ]
@@ -3166,57 +3166,9 @@
       ]
     },
     {
-      "name": "filters, floor, positive float",
-      "template": "{{ 5.4 | floor }}",
-      "result": "5",
-      "tags": [
-        "floor filter"
-      ]
-    },
-    {
-      "name": "filters, floor, negative float",
-      "template": "{{ -5.4 | floor }}",
-      "result": "-6",
-      "tags": [
-        "floor filter"
-      ]
-    },
-    {
-      "name": "filters, floor, zero",
-      "template": "{{ 0 | floor }}",
-      "result": "0",
-      "tags": [
-        "floor filter"
-      ]
-    },
-    {
-      "name": "filters, floor, positive string float",
-      "template": "{{ \"5.1\" | floor }}",
-      "result": "5",
-      "tags": [
-        "floor filter"
-      ]
-    },
-    {
       "name": "filters, floor, negative string float",
       "template": "{{ \"-5.1\" | floor }}",
       "result": "-6",
-      "tags": [
-        "floor filter"
-      ]
-    },
-    {
-      "name": "filters, floor, unexpected argument",
-      "template": "{{ -3.1 | floor: 1 }}",
-      "invalid": true,
-      "tags": [
-        "floor filter"
-      ]
-    },
-    {
-      "name": "filters, floor, string not a number",
-      "template": "{{ \"hello\" | floor }}",
-      "result": "0",
       "tags": [
         "floor filter"
       ]
@@ -3233,6 +3185,38 @@
       ]
     },
     {
+      "name": "filters, floor, positive float",
+      "template": "{{ 5.4 | floor }}",
+      "result": "5",
+      "tags": [
+        "floor filter"
+      ]
+    },
+    {
+      "name": "filters, floor, positive integer",
+      "template": "{{ 5 | floor }}",
+      "result": "5",
+      "tags": [
+        "floor filter"
+      ]
+    },
+    {
+      "name": "filters, floor, positive string float",
+      "template": "{{ \"5.1\" | floor }}",
+      "result": "5",
+      "tags": [
+        "floor filter"
+      ]
+    },
+    {
+      "name": "filters, floor, string not a number",
+      "template": "{{ \"hello\" | floor }}",
+      "result": "0",
+      "tags": [
+        "floor filter"
+      ]
+    },
+    {
       "name": "filters, floor, undefined left value",
       "template": "{{ nosuchthing | floor }}",
       "result": "0",
@@ -3241,46 +3225,126 @@
       ]
     },
     {
-      "name": "filters, has, array of strings, default value",
-      "template": "{{ a | has: 'z' }}",
-      "data": {
-        "a": [
-          "x",
-          "y",
-          "z"
-        ]
-      },
-      "result": "true",
+      "name": "filters, floor, unexpected argument",
+      "template": "{{ -3.1 | floor: 1 }}",
+      "invalid": true,
       "tags": [
-        "has filter"
+        "floor filter"
       ]
     },
     {
-      "name": "filters, has, array of strings, default value, substring match",
-      "template": "{{ a | has: 'z' }}",
-      "data": {
-        "a": [
-          "x",
-          "y",
-          "zoo"
-        ]
-      },
-      "result": "true",
+      "name": "filters, floor, zero",
+      "template": "{{ 0 | floor }}",
+      "result": "0",
       "tags": [
-        "has filter"
+        "floor filter"
       ]
     },
     {
-      "name": "filters, has, array of strings, default value, no match",
-      "template": "{{ a | has: ':(' }}",
+      "name": "filters, has, array of hashes, false property",
+      "template": "{{ a | has: false }}",
       "data": {
         "a": [
-          "x",
-          "y",
-          "z"
+          {
+            "x": 99
+          },
+          {
+            "z": 42
+          }
         ]
       },
       "result": "false",
+      "tags": [
+        "has filter"
+      ]
+    },
+    {
+      "name": "filters, has, array of hashes, int property",
+      "template": "{{ a | has: 42 }}",
+      "data": {
+        "a": [
+          {
+            "x": 99
+          },
+          {
+            "z": 42
+          }
+        ]
+      },
+      "result": "false",
+      "tags": [
+        "has filter"
+      ]
+    },
+    {
+      "name": "filters, has, array of hashes, int value, match",
+      "template": "{{ a | has: 'z', 42 }}",
+      "data": {
+        "a": [
+          {
+            "x": 99
+          },
+          {
+            "z": 42
+          }
+        ]
+      },
+      "result": "true",
+      "tags": [
+        "has filter"
+      ]
+    },
+    {
+      "name": "filters, has, array of hashes, int value, no match",
+      "template": "{{ a | has: 'z', 7 }}",
+      "data": {
+        "a": [
+          {
+            "x": 99
+          },
+          {
+            "z": 42
+          }
+        ]
+      },
+      "result": "false",
+      "tags": [
+        "has filter"
+      ]
+    },
+    {
+      "name": "filters, has, array of hashes, nil property",
+      "template": "{{ a | has: nil }}",
+      "data": {
+        "a": [
+          {
+            "x": 99
+          },
+          {
+            "z": 42
+          }
+        ]
+      },
+      "result": "false",
+      "tags": [
+        "has filter"
+      ]
+    },
+    {
+      "name": "filters, has, array of hashes, with a nil",
+      "template": "{{ a | has: 'z', 42 }}",
+      "data": {
+        "a": [
+          {
+            "x": 99
+          },
+          null,
+          {
+            "z": 42
+          }
+        ]
+      },
+      "result": "",
       "tags": [
         "has filter"
       ]
@@ -3316,27 +3380,14 @@
       ]
     },
     {
-      "name": "filters, has, mixed array, default value",
+      "name": "filters, has, array of strings, default value",
       "template": "{{ a | has: 'z' }}",
       "data": {
         "a": [
           "x",
-          null,
-          "z",
-          false,
-          true
+          "y",
+          "z"
         ]
-      },
-      "result": "",
-      "tags": [
-        "has filter"
-      ]
-    },
-    {
-      "name": "filters, has, string input, default value, match",
-      "template": "{{ a | has: 'z' }}",
-      "data": {
-        "a": "zoo"
       },
       "result": "true",
       "tags": [
@@ -3344,12 +3395,31 @@
       ]
     },
     {
-      "name": "filters, has, string input, default value, no match",
-      "template": "{{ a | has: 'z' }}",
+      "name": "filters, has, array of strings, default value, no match",
+      "template": "{{ a | has: ':(' }}",
       "data": {
-        "a": "foo"
+        "a": [
+          "x",
+          "y",
+          "z"
+        ]
       },
       "result": "false",
+      "tags": [
+        "has filter"
+      ]
+    },
+    {
+      "name": "filters, has, array of strings, default value, substring match",
+      "template": "{{ a | has: 'z' }}",
+      "data": {
+        "a": [
+          "x",
+          "y",
+          "zoo"
+        ]
+      },
+      "result": "true",
       "tags": [
         "has filter"
       ]
@@ -3376,6 +3446,45 @@
         }
       },
       "result": "false",
+      "tags": [
+        "has filter"
+      ]
+    },
+    {
+      "name": "filters, has, hash input, explicit nil, match",
+      "template": "{{ a | has: 'z', nil }}",
+      "data": {
+        "a": {
+          "z": null
+        }
+      },
+      "result": "false",
+      "tags": [
+        "has filter"
+      ]
+    },
+    {
+      "name": "filters, has, hash input, explicit nil, no match",
+      "template": "{{ a | has: 'z', nil }}",
+      "data": {
+        "a": {
+          "z": 42
+        }
+      },
+      "result": "true",
+      "tags": [
+        "has filter"
+      ]
+    },
+    {
+      "name": "filters, has, hash input, false value, match",
+      "template": "{{ a | has: 'z', false }}",
+      "data": {
+        "a": {
+          "z": false
+        }
+      },
+      "result": "true",
       "tags": [
         "has filter"
       ]
@@ -3420,92 +3529,15 @@
       ]
     },
     {
-      "name": "filters, has, hash input, explicit nil, no match",
-      "template": "{{ a | has: 'z', nil }}",
-      "data": {
-        "a": {
-          "z": 42
-        }
-      },
-      "result": "true",
-      "tags": [
-        "has filter"
-      ]
-    },
-    {
-      "name": "filters, has, hash input, explicit nil, match",
-      "template": "{{ a | has: 'z', nil }}",
-      "data": {
-        "a": {
-          "z": null
-        }
-      },
-      "result": "false",
-      "tags": [
-        "has filter"
-      ]
-    },
-    {
-      "name": "filters, has, hash input, false value, match",
-      "template": "{{ a | has: 'z', false }}",
-      "data": {
-        "a": {
-          "z": false
-        }
-      },
-      "result": "true",
-      "tags": [
-        "has filter"
-      ]
-    },
-    {
-      "name": "filters, has, array of hashes, int value, match",
-      "template": "{{ a | has: 'z', 42 }}",
+      "name": "filters, has, mixed array, default value",
+      "template": "{{ a | has: 'z' }}",
       "data": {
         "a": [
-          {
-            "x": 99
-          },
-          {
-            "z": 42
-          }
-        ]
-      },
-      "result": "true",
-      "tags": [
-        "has filter"
-      ]
-    },
-    {
-      "name": "filters, has, array of hashes, int value, no match",
-      "template": "{{ a | has: 'z', 7 }}",
-      "data": {
-        "a": [
-          {
-            "x": 99
-          },
-          {
-            "z": 42
-          }
-        ]
-      },
-      "result": "false",
-      "tags": [
-        "has filter"
-      ]
-    },
-    {
-      "name": "filters, has, array of hashes, with a nil",
-      "template": "{{ a | has: 'z', 42 }}",
-      "data": {
-        "a": [
-          {
-            "x": 99
-          },
+          "x",
           null,
-          {
-            "z": 42
-          }
+          "z",
+          false,
+          true
         ]
       },
       "result": "",
@@ -3514,17 +3546,21 @@
       ]
     },
     {
-      "name": "filters, has, array of hashes, nil property",
-      "template": "{{ a | has: nil }}",
+      "name": "filters, has, string input, default value, match",
+      "template": "{{ a | has: 'z' }}",
       "data": {
-        "a": [
-          {
-            "x": 99
-          },
-          {
-            "z": 42
-          }
-        ]
+        "a": "zoo"
+      },
+      "result": "true",
+      "tags": [
+        "has filter"
+      ]
+    },
+    {
+      "name": "filters, has, string input, default value, no match",
+      "template": "{{ a | has: 'z' }}",
+      "data": {
+        "a": "foo"
       },
       "result": "false",
       "tags": [
@@ -3532,45 +3568,43 @@
       ]
     },
     {
-      "name": "filters, has, array of hashes, int property",
-      "template": "{{ a | has: 42 }}",
+      "name": "filters, join, argument is not a string",
+      "template": "{{ arr | join: 5 }}",
       "data": {
-        "a": [
-          {
-            "x": 99
-          },
-          {
-            "z": 42
-          }
+        "arr": [
+          "a",
+          "b"
         ]
       },
-      "result": "false",
+      "result": "a5b",
       "tags": [
-        "has filter"
+        "join filter"
       ]
     },
     {
-      "name": "filters, has, array of hashes, false property",
-      "template": "{{ a | has: false }}",
+      "name": "filters, join, join an array of integers",
+      "template": "{{ arr | join: '#' }}",
       "data": {
-        "a": [
-          {
-            "x": 99
-          },
-          {
-            "z": 42
-          }
+        "arr": [
+          1,
+          2
         ]
       },
-      "result": "false",
+      "result": "1#2",
       "tags": [
-        "has filter"
+        "join filter"
       ]
     },
     {
-      "name": "filters, join, range literal join filter left value",
-      "template": "{{ (1..3) | join: '#' }}",
-      "result": "1#2#3",
+      "name": "filters, join, join an array of strings",
+      "template": "{{ arr | join: '#' }}",
+      "data": {
+        "arr": [
+          "a",
+          "b"
+        ]
+      },
+      "result": "a#b",
       "tags": [
         "join filter"
       ]
@@ -3592,29 +3626,16 @@
       ]
     },
     {
-      "name": "filters, join, join an array of strings",
+      "name": "filters, join, left value contains non string",
       "template": "{{ arr | join: '#' }}",
       "data": {
         "arr": [
           "a",
-          "b"
+          "b",
+          1
         ]
       },
-      "result": "a#b",
-      "tags": [
-        "join filter"
-      ]
-    },
-    {
-      "name": "filters, join, join an array of integers",
-      "template": "{{ arr | join: '#' }}",
-      "data": {
-        "arr": [
-          1,
-          2
-        ]
-      },
-      "result": "1#2",
+      "result": "a#b#1",
       "tags": [
         "join filter"
       ]
@@ -3634,52 +3655,9 @@
       ]
     },
     {
-      "name": "filters, join, argument is not a string",
-      "template": "{{ arr | join: 5 }}",
-      "data": {
-        "arr": [
-          "a",
-          "b"
-        ]
-      },
-      "result": "a5b",
-      "tags": [
-        "join filter"
-      ]
-    },
-    {
-      "name": "filters, join, left value contains non string",
-      "template": "{{ arr | join: '#' }}",
-      "data": {
-        "arr": [
-          "a",
-          "b",
-          1
-        ]
-      },
-      "result": "a#b#1",
-      "tags": [
-        "join filter"
-      ]
-    },
-    {
-      "name": "filters, join, undefined left value",
-      "template": "{{ nosuchthing | join: '#' }}",
-      "result": "",
-      "tags": [
-        "join filter"
-      ]
-    },
-    {
-      "name": "filters, join, undefined argument",
-      "template": "{{ arr | join: nosuchthing }}",
-      "data": {
-        "arr": [
-          "a",
-          "b"
-        ]
-      },
-      "result": "ab",
+      "name": "filters, join, range literal join filter left value",
+      "template": "{{ (1..3) | join: '#' }}",
+      "result": "1#2#3",
       "tags": [
         "join filter"
       ]
@@ -3699,11 +3677,25 @@
       ]
     },
     {
-      "name": "filters, last, range literal last filter left value",
-      "template": "{{ (1..3) | last }}",
-      "result": "3",
+      "name": "filters, join, undefined argument",
+      "template": "{{ arr | join: nosuchthing }}",
+      "data": {
+        "arr": [
+          "a",
+          "b"
+        ]
+      },
+      "result": "ab",
       "tags": [
-        "last filter"
+        "join filter"
+      ]
+    },
+    {
+      "name": "filters, join, undefined left value",
+      "template": "{{ nosuchthing | join: '#' }}",
+      "result": "",
+      "tags": [
+        "join filter"
       ]
     },
     {
@@ -3749,19 +3741,14 @@
       ]
     },
     {
-      "name": "filters, last, left value not an array",
-      "template": "{{ arr | last }}",
+      "name": "filters, last, last of a hash",
+      "template": "{{ a | last }}",
       "data": {
-        "arr": 12
+        "a": {
+          "b": 1,
+          "c": 2
+        }
       },
-      "result": "",
-      "tags": [
-        "last filter"
-      ]
-    },
-    {
-      "name": "filters, last, left value is undefined",
-      "template": "{{ nosuchthing | last }}",
       "result": "",
       "tags": [
         "last filter"
@@ -3779,13 +3766,18 @@
       ]
     },
     {
-      "name": "filters, last, last of a hash",
-      "template": "{{ a | last }}",
+      "name": "filters, last, left value is undefined",
+      "template": "{{ nosuchthing | last }}",
+      "result": "",
+      "tags": [
+        "last filter"
+      ]
+    },
+    {
+      "name": "filters, last, left value not an array",
+      "template": "{{ arr | last }}",
       "data": {
-        "a": {
-          "b": 1,
-          "c": 2
-        }
+        "arr": 12
       },
       "result": "",
       "tags": [
@@ -3793,25 +3785,25 @@
       ]
     },
     {
-      "name": "filters, lstrip, left padded",
-      "template": "{{ \" \t\r\n  hello\" | lstrip }}",
-      "result": "hello",
+      "name": "filters, last, range literal last filter left value",
+      "template": "{{ (1..3) | last }}",
+      "result": "3",
       "tags": [
-        "lstrip filter"
-      ]
-    },
-    {
-      "name": "filters, lstrip, right padded",
-      "template": "{{ \"hello \t\r\n  \" | lstrip }}",
-      "result": "hello \t\r\n  ",
-      "tags": [
-        "lstrip filter"
+        "last filter"
       ]
     },
     {
       "name": "filters, lstrip, left and right padded",
       "template": "{{ \" \t\r\n  hello  \t\r\n \" | lstrip }}",
       "result": "hello  \t\r\n ",
+      "tags": [
+        "lstrip filter"
+      ]
+    },
+    {
+      "name": "filters, lstrip, left padded",
+      "template": "{{ \" \t\r\n  hello\" | lstrip }}",
+      "result": "hello",
       "tags": [
         "lstrip filter"
       ]
@@ -3825,9 +3817,9 @@
       ]
     },
     {
-      "name": "filters, lstrip, unexpected argument",
-      "template": "{{ \"hello\" | lstrip: 5 }}",
-      "invalid": true,
+      "name": "filters, lstrip, right padded",
+      "template": "{{ \"hello \t\r\n  \" | lstrip }}",
+      "result": "hello \t\r\n  ",
       "tags": [
         "lstrip filter"
       ]
@@ -3838,6 +3830,55 @@
       "result": "",
       "tags": [
         "lstrip filter"
+      ]
+    },
+    {
+      "name": "filters, lstrip, unexpected argument",
+      "template": "{{ \"hello\" | lstrip: 5 }}",
+      "invalid": true,
+      "tags": [
+        "lstrip filter"
+      ]
+    },
+    {
+      "name": "filters, map, argument is explicit nil",
+      "template": "{% assign b = a | map: nil %}{% for x in b %}{% for y in x %}{{ y[0] }}:{{ y[1] }},{% endfor %}{% endfor %}",
+      "data": {
+        "a": [
+          {
+            "title": "foo"
+          },
+          {
+            "title": "bar"
+          }
+        ]
+      },
+      "result": "title:foo,title:bar,",
+      "tags": [
+        "assign tag",
+        "for tag",
+        "map filter"
+      ]
+    },
+    {
+      "name": "filters, map, array containing a non object",
+      "template": "{{ a | map: 'title' | join: '#' }}",
+      "data": {
+        "a": [
+          {
+            "title": "foo"
+          },
+          {
+            "title": "bar"
+          },
+          5,
+          []
+        ]
+      },
+      "invalid": true,
+      "tags": [
+        "join filter",
+        "map filter"
       ]
     },
     {
@@ -3857,6 +3898,33 @@
         ]
       },
       "result": "foo#bar#baz",
+      "tags": [
+        "join filter",
+        "map filter"
+      ]
+    },
+    {
+      "name": "filters, map, input is a hash",
+      "template": "{{ a | map: 'title' | join: '#' }}",
+      "data": {
+        "a": {
+          "title": "foo",
+          "some": "thing"
+        }
+      },
+      "result": "foo",
+      "tags": [
+        "join filter",
+        "map filter"
+      ]
+    },
+    {
+      "name": "filters, map, left value not an array",
+      "template": "{{ a | map: 'title' | join: '#' }}",
+      "data": {
+        "a": 123
+      },
+      "invalid": true,
       "tags": [
         "join filter",
         "map filter"
@@ -3885,33 +3953,24 @@
       ]
     },
     {
-      "name": "filters, map, left value not an array",
-      "template": "{{ a | map: 'title' | join: '#' }}",
-      "data": {
-        "a": 123
-      },
-      "invalid": true,
-      "tags": [
-        "join filter",
-        "map filter"
-      ]
-    },
-    {
-      "name": "filters, map, array containing a non object",
+      "name": "filters, map, nested arrays get flattened",
       "template": "{{ a | map: 'title' | join: '#' }}",
       "data": {
         "a": [
           {
             "title": "foo"
           },
-          {
-            "title": "bar"
-          },
-          5,
-          []
+          [
+            {
+              "title": "bar"
+            },
+            {
+              "title": "baz"
+            }
+          ]
         ]
       },
-      "invalid": true,
+      "result": "foo#bar#baz",
       "tags": [
         "join filter",
         "map filter"
@@ -3938,76 +3997,9 @@
       ]
     },
     {
-      "name": "filters, map, argument is explicit nil",
-      "template": "{% assign b = a | map: nil %}{% for x in b %}{% for y in x %}{{ y[0] }}:{{ y[1] }},{% endfor %}{% endfor %}",
-      "data": {
-        "a": [
-          {
-            "title": "foo"
-          },
-          {
-            "title": "bar"
-          }
-        ]
-      },
-      "result": "title:foo,title:bar,",
-      "tags": [
-        "assign tag",
-        "for tag",
-        "map filter"
-      ]
-    },
-    {
-      "name": "filters, map, nested arrays get flattened",
-      "template": "{{ a | map: 'title' | join: '#' }}",
-      "data": {
-        "a": [
-          {
-            "title": "foo"
-          },
-          [
-            {
-              "title": "bar"
-            },
-            {
-              "title": "baz"
-            }
-          ]
-        ]
-      },
-      "result": "foo#bar#baz",
-      "tags": [
-        "join filter",
-        "map filter"
-      ]
-    },
-    {
-      "name": "filters, map, input is a hash",
-      "template": "{{ a | map: 'title' | join: '#' }}",
-      "data": {
-        "a": {
-          "title": "foo",
-          "some": "thing"
-        }
-      },
-      "result": "foo",
-      "tags": [
-        "join filter",
-        "map filter"
-      ]
-    },
-    {
-      "name": "filters, minus, integer value and integer arg",
-      "template": "{{ 10 | minus: 2 }}",
-      "result": "8",
-      "tags": [
-        "minus filter"
-      ]
-    },
-    {
-      "name": "filters, minus, integer value and float arg",
-      "template": "{{ 10 | minus: 2.0 }}",
-      "result": "8.0",
+      "name": "filters, minus, arg string not a number",
+      "template": "{{ \"10\" | minus: \"foo\" }}",
+      "result": "10",
       "tags": [
         "minus filter"
       ]
@@ -4021,33 +4013,17 @@
       ]
     },
     {
-      "name": "filters, minus, string value and string arg",
-      "template": "{{ \"10.1\" | minus: \"2.2\" }}",
-      "result": "7.9",
+      "name": "filters, minus, integer value and float arg",
+      "template": "{{ 10 | minus: 2.0 }}",
+      "result": "8.0",
       "tags": [
         "minus filter"
       ]
     },
     {
-      "name": "filters, minus, string not a number",
-      "template": "{{ \"foo\" | minus: \"2.0\" }}",
-      "result": "-2.0",
-      "tags": [
-        "minus filter"
-      ]
-    },
-    {
-      "name": "filters, minus, arg string not a number",
-      "template": "{{ \"10\" | minus: \"foo\" }}",
-      "result": "10",
-      "tags": [
-        "minus filter"
-      ]
-    },
-    {
-      "name": "filters, minus, too many args",
-      "template": "{{ 5 | minus: 1, '5' }}",
-      "invalid": true,
+      "name": "filters, minus, integer value and integer arg",
+      "template": "{{ 10 | minus: 2 }}",
+      "result": "8",
       "tags": [
         "minus filter"
       ]
@@ -4064,9 +4040,25 @@
       ]
     },
     {
-      "name": "filters, minus, undefined left value",
-      "template": "{{ nosuchthing | minus: 2 }}",
-      "result": "-2",
+      "name": "filters, minus, string not a number",
+      "template": "{{ \"foo\" | minus: \"2.0\" }}",
+      "result": "-2.0",
+      "tags": [
+        "minus filter"
+      ]
+    },
+    {
+      "name": "filters, minus, string value and string arg",
+      "template": "{{ \"10.1\" | minus: \"2.2\" }}",
+      "result": "7.9",
+      "tags": [
+        "minus filter"
+      ]
+    },
+    {
+      "name": "filters, minus, too many args",
+      "template": "{{ 5 | minus: 1, '5' }}",
+      "invalid": true,
       "tags": [
         "minus filter"
       ]
@@ -4080,17 +4072,17 @@
       ]
     },
     {
-      "name": "filters, modulo, integer value and integer arg",
-      "template": "{{ 10 | modulo: 2 }}",
-      "result": "0",
+      "name": "filters, minus, undefined left value",
+      "template": "{{ nosuchthing | minus: 2 }}",
+      "result": "-2",
       "tags": [
-        "modulo filter"
+        "minus filter"
       ]
     },
     {
-      "name": "filters, modulo, integer value and float arg",
-      "template": "{{ 10 | modulo: 2.0 }}",
-      "result": "0.0",
+      "name": "filters, modulo, arg string not a number",
+      "template": "{{ \"10\" | modulo: \"foo\" }}",
+      "invalid": true,
       "tags": [
         "modulo filter"
       ]
@@ -4104,33 +4096,17 @@
       ]
     },
     {
-      "name": "filters, modulo, string value and argument",
-      "template": "{{ \"10\" | modulo: \"2.0\" }}",
+      "name": "filters, modulo, integer value and float arg",
+      "template": "{{ 10 | modulo: 2.0 }}",
       "result": "0.0",
       "tags": [
         "modulo filter"
       ]
     },
     {
-      "name": "filters, modulo, string not a number",
-      "template": "{{ \"foo\" | modulo: \"2.0\" }}",
-      "result": "0.0",
-      "tags": [
-        "modulo filter"
-      ]
-    },
-    {
-      "name": "filters, modulo, arg string not a number",
-      "template": "{{ \"10\" | modulo: \"foo\" }}",
-      "invalid": true,
-      "tags": [
-        "modulo filter"
-      ]
-    },
-    {
-      "name": "filters, modulo, too many args",
-      "template": "{{ 5 | modulo: 1, '5' }}",
-      "invalid": true,
+      "name": "filters, modulo, integer value and integer arg",
+      "template": "{{ 10 | modulo: 2 }}",
+      "result": "0",
       "tags": [
         "modulo filter"
       ]
@@ -4147,9 +4123,25 @@
       ]
     },
     {
-      "name": "filters, modulo, undefined left value",
-      "template": "{{ nosuchthing | modulo: 2 }}",
-      "result": "0",
+      "name": "filters, modulo, string not a number",
+      "template": "{{ \"foo\" | modulo: \"2.0\" }}",
+      "result": "0.0",
+      "tags": [
+        "modulo filter"
+      ]
+    },
+    {
+      "name": "filters, modulo, string value and argument",
+      "template": "{{ \"10\" | modulo: \"2.0\" }}",
+      "result": "0.0",
+      "tags": [
+        "modulo filter"
+      ]
+    },
+    {
+      "name": "filters, modulo, too many args",
+      "template": "{{ 5 | modulo: 1, '5' }}",
+      "invalid": true,
       "tags": [
         "modulo filter"
       ]
@@ -4163,25 +4155,17 @@
       ]
     },
     {
-      "name": "filters, newline to br, string with newlines",
-      "template": "{{ \"- apples\n- oranges\n\" | newline_to_br }}",
-      "result": "- apples<br />\n- oranges<br />\n",
+      "name": "filters, modulo, undefined left value",
+      "template": "{{ nosuchthing | modulo: 2 }}",
+      "result": "0",
       "tags": [
-        "newline_to_br filter"
+        "modulo filter"
       ]
     },
     {
       "name": "filters, newline to br, not a string",
       "template": "{{ 5 | newline_to_br }}",
       "result": "5",
-      "tags": [
-        "newline_to_br filter"
-      ]
-    },
-    {
-      "name": "filters, newline to br, unexpected argument",
-      "template": "{{ \"hello\" | newline_to_br: 5 }}",
-      "invalid": true,
       "tags": [
         "newline_to_br filter"
       ]
@@ -4203,6 +4187,14 @@
       ]
     },
     {
+      "name": "filters, newline to br, string with newlines",
+      "template": "{{ \"- apples\n- oranges\n\" | newline_to_br }}",
+      "result": "- apples<br />\n- oranges<br />\n",
+      "tags": [
+        "newline_to_br filter"
+      ]
+    },
+    {
       "name": "filters, newline to br, undefined left value",
       "template": "{{ nosuchthing | newline_to_br }}",
       "result": "",
@@ -4211,17 +4203,17 @@
       ]
     },
     {
-      "name": "filters, plus, integer value and integer arg",
-      "template": "{{ 10 | plus: 2 }}",
-      "result": "12",
+      "name": "filters, newline to br, unexpected argument",
+      "template": "{{ \"hello\" | newline_to_br: 5 }}",
+      "invalid": true,
       "tags": [
-        "plus filter"
+        "newline_to_br filter"
       ]
     },
     {
-      "name": "filters, plus, integer value and float arg",
-      "template": "{{ 10 | plus: 2.0 }}",
-      "result": "12.0",
+      "name": "filters, plus, arg string not a number",
+      "template": "{{ \"10\" | plus: \"foo\" }}",
+      "result": "10",
       "tags": [
         "plus filter"
       ]
@@ -4235,33 +4227,25 @@
       ]
     },
     {
-      "name": "filters, plus, string value and string arg",
-      "template": "{{ \"10.1\" | plus: \"2.2\" }}",
-      "result": "12.3",
+      "name": "filters, plus, integer value and float arg",
+      "template": "{{ 10 | plus: 2.0 }}",
+      "result": "12.0",
       "tags": [
         "plus filter"
       ]
     },
     {
-      "name": "filters, plus, string not a number",
-      "template": "{{ \"foo\" | plus: \"2.0\" }}",
-      "result": "2.0",
+      "name": "filters, plus, integer value and integer arg",
+      "template": "{{ 10 | plus: 2 }}",
+      "result": "12",
       "tags": [
         "plus filter"
       ]
     },
     {
-      "name": "filters, plus, arg string not a number",
-      "template": "{{ \"10\" | plus: \"foo\" }}",
-      "result": "10",
-      "tags": [
-        "plus filter"
-      ]
-    },
-    {
-      "name": "filters, plus, too many args",
-      "template": "{{ 5 | plus: 1, '5' }}",
-      "invalid": true,
+      "name": "filters, plus, integer value and negative integer arg",
+      "template": "{{ 10 | plus: -2 }}",
+      "result": "8",
       "tags": [
         "plus filter"
       ]
@@ -4278,9 +4262,25 @@
       ]
     },
     {
-      "name": "filters, plus, undefined left value",
-      "template": "{{ nosuchthing | plus: 2 }}",
-      "result": "2",
+      "name": "filters, plus, string not a number",
+      "template": "{{ \"foo\" | plus: \"2.0\" }}",
+      "result": "2.0",
+      "tags": [
+        "plus filter"
+      ]
+    },
+    {
+      "name": "filters, plus, string value and string arg",
+      "template": "{{ \"10.1\" | plus: \"2.2\" }}",
+      "result": "12.3",
+      "tags": [
+        "plus filter"
+      ]
+    },
+    {
+      "name": "filters, plus, too many args",
+      "template": "{{ 5 | plus: 1, '5' }}",
+      "invalid": true,
       "tags": [
         "plus filter"
       ]
@@ -4294,33 +4294,25 @@
       ]
     },
     {
-      "name": "filters, plus, integer value and negative integer arg",
-      "template": "{{ 10 | plus: -2 }}",
-      "result": "8",
+      "name": "filters, plus, undefined left value",
+      "template": "{{ nosuchthing | plus: 2 }}",
+      "result": "2",
       "tags": [
         "plus filter"
-      ]
-    },
-    {
-      "name": "filters, prepend, concat",
-      "template": "{{ \"hello\" | prepend: \"there\" }}",
-      "result": "therehello",
-      "tags": [
-        "prepend filter"
-      ]
-    },
-    {
-      "name": "filters, prepend, not a string",
-      "template": "{{ 5 | prepend: 'there' }}",
-      "result": "there5",
-      "tags": [
-        "prepend filter"
       ]
     },
     {
       "name": "filters, prepend, argument not a string",
       "template": "{{ \"hello\" | prepend: 5 }}",
       "result": "5hello",
+      "tags": [
+        "prepend filter"
+      ]
+    },
+    {
+      "name": "filters, prepend, concat",
+      "template": "{{ \"hello\" | prepend: \"there\" }}",
+      "result": "therehello",
       "tags": [
         "prepend filter"
       ]
@@ -4334,17 +4326,17 @@
       ]
     },
     {
-      "name": "filters, prepend, too many arguments",
-      "template": "{{ \"hello\" | prepend: \"how\", \"are\", \"you\" }}",
-      "invalid": true,
+      "name": "filters, prepend, not a string",
+      "template": "{{ 5 | prepend: 'there' }}",
+      "result": "there5",
       "tags": [
         "prepend filter"
       ]
     },
     {
-      "name": "filters, prepend, undefined left value",
-      "template": "{{ nosuchthing | prepend: \"hi\" }}",
-      "result": "hi",
+      "name": "filters, prepend, too many arguments",
+      "template": "{{ \"hello\" | prepend: \"how\", \"are\", \"you\" }}",
+      "invalid": true,
       "tags": [
         "prepend filter"
       ]
@@ -4358,19 +4350,26 @@
       ]
     },
     {
-      "name": "filters, reject, array of strings, default value",
-      "template": "{% assign b = a | reject: 'c' %}{% for obj in b %}{{ obj }}, {% endfor %}",
+      "name": "filters, prepend, undefined left value",
+      "template": "{{ nosuchthing | prepend: \"hi\" }}",
+      "result": "hi",
+      "tags": [
+        "prepend filter"
+      ]
+    },
+    {
+      "name": "filters, reject, array containing an int, default value",
+      "template": "{{ a | reject: 'c' }}",
       "data": {
         "a": [
           "x",
           "y",
-          "cat"
+          "cat",
+          1
         ]
       },
-      "result": "x, y, ",
+      "invalid": true,
       "tags": [
-        "assign tag",
-        "for tag",
         "reject filter"
       ]
     },
@@ -4391,50 +4390,8 @@
       ]
     },
     {
-      "name": "filters, reject, array containing an int, default value",
-      "template": "{{ a | reject: 'c' }}",
-      "data": {
-        "a": [
-          "x",
-          "y",
-          "cat",
-          1
-        ]
-      },
-      "invalid": true,
-      "tags": [
-        "reject filter"
-      ]
-    },
-    {
       "name": "filters, reject, array of hashes, default value",
       "template": "{% assign b = a | reject: 'title' %}{% for obj in b %}{% for itm in obj %}({{ itm[0] }},{{ itm[1] }}), {% endfor %}{% endfor %}",
-      "data": {
-        "a": [
-          {
-            "title": "foo"
-          },
-          {
-            "title": false
-          },
-          {
-            "title": null
-          },
-          {
-            "heading": "baz"
-          }
-        ]
-      },
-      "result": "(title,false), (title,), (heading,baz), ",
-      "tags": [
-        "assign tag",
-        "for tag",
-        "reject filter"
-      ]
-    },
-    {
-      "name": "filters, reject, array of hashes, explicit nil",
-      "template": "{% assign b = a | reject: 'title', nil %}{% for obj in b %}{% for itm in obj %}({{ itm[0] }},{{ itm[1] }}), {% endfor %}{% endfor %}",
       "data": {
         "a": [
           {
@@ -4485,6 +4442,32 @@
       ]
     },
     {
+      "name": "filters, reject, array of hashes, explicit nil",
+      "template": "{% assign b = a | reject: 'title', nil %}{% for obj in b %}{% for itm in obj %}({{ itm[0] }},{{ itm[1] }}), {% endfor %}{% endfor %}",
+      "data": {
+        "a": [
+          {
+            "title": "foo"
+          },
+          {
+            "title": false
+          },
+          {
+            "title": null
+          },
+          {
+            "heading": "baz"
+          }
+        ]
+      },
+      "result": "(title,false), (title,), (heading,baz), ",
+      "tags": [
+        "assign tag",
+        "for tag",
+        "reject filter"
+      ]
+    },
+    {
       "name": "filters, reject, array of hashes, explicit true",
       "template": "{% assign b = a | reject: 'title', true %}{% for obj in b %}{% for itm in obj %}({{ itm[0] }},{{ itm[1] }}), {% endfor %}{% endfor %}",
       "data": {
@@ -4501,6 +4484,29 @@
         ]
       },
       "result": "(title,bar), (title,), ",
+      "tags": [
+        "assign tag",
+        "for tag",
+        "reject filter"
+      ]
+    },
+    {
+      "name": "filters, reject, array of hashes, missing property",
+      "template": "{% assign b = a | reject: 'title', 'bar' %}{% for obj in b %}{% for itm in obj %}({{ itm[0] }},{{ itm[1] }}), {% endfor %}{% endfor %}",
+      "data": {
+        "a": [
+          {
+            "heading": "foo"
+          },
+          {
+            "title": "bar"
+          },
+          {
+            "title": null
+          }
+        ]
+      },
+      "result": "(heading,foo), (title,), ",
       "tags": [
         "assign tag",
         "for tag",
@@ -4534,31 +4540,8 @@
       ]
     },
     {
-      "name": "filters, reject, array of hashes, missing property",
-      "template": "{% assign b = a | reject: 'title', 'bar' %}{% for obj in b %}{% for itm in obj %}({{ itm[0] }},{{ itm[1] }}), {% endfor %}{% endfor %}",
-      "data": {
-        "a": [
-          {
-            "heading": "foo"
-          },
-          {
-            "title": "bar"
-          },
-          {
-            "title": null
-          }
-        ]
-      },
-      "result": "(heading,foo), (title,), ",
-      "tags": [
-        "assign tag",
-        "for tag",
-        "reject filter"
-      ]
-    },
-    {
-      "name": "filters, reject, missing argument",
-      "template": "{% assign b = a | reject %}{% for obj in b %}{{ obj }}, {% endfor %}",
+      "name": "filters, reject, array of strings, default value",
+      "template": "{% assign b = a | reject: 'c' %}{% for obj in b %}{{ obj }}, {% endfor %}",
       "data": {
         "a": [
           "x",
@@ -4566,27 +4549,7 @@
           "cat"
         ]
       },
-      "invalid": true,
-      "tags": [
-        "assign tag",
-        "for tag",
-        "reject filter"
-      ]
-    },
-    {
-      "name": "filters, reject, too many arguments",
-      "template": "{% assign b = a | reject: 'x', 'y', 'z' %}{% for obj in b %}{{ obj }}, {% endfor %}",
-      "invalid": true,
-      "tags": [
-        "assign tag",
-        "for tag",
-        "reject filter"
-      ]
-    },
-    {
-      "name": "filters, reject, input is undefined",
-      "template": "{% assign b = nosuchthing | reject: 'c' %}{% for obj in b %}{{ obj }}, {% endfor %}",
-      "result": "",
+      "result": "x, y, ",
       "tags": [
         "assign tag",
         "for tag",
@@ -4611,29 +4574,6 @@
       ]
     },
     {
-      "name": "filters, reject, second argument is undefined",
-      "template": "{% assign b = a | reject: 'title', nosuchthing %}{% for obj in b %}{% for itm in obj %}({{ itm[0] }},{{ itm[1] }}), {% endfor %}{% endfor %}",
-      "data": {
-        "a": [
-          {
-            "title": "foo"
-          },
-          {
-            "title": "bar"
-          },
-          {
-            "title": null
-          }
-        ]
-      },
-      "result": "(title,), ",
-      "tags": [
-        "assign tag",
-        "for tag",
-        "reject filter"
-      ]
-    },
-    {
       "name": "filters, reject, input is a hash, default value",
       "template": "{% assign b = h | reject: 'bar' %}{% for obj in b %}{{ obj }}, {% endfor %}",
       "data": {
@@ -4644,23 +4584,6 @@
         }
       },
       "result": "",
-      "tags": [
-        "assign tag",
-        "for tag",
-        "reject filter"
-      ]
-    },
-    {
-      "name": "filters, reject, input is a hash, default value, no match",
-      "template": "{% assign b = h | reject: 'barbar' %}{% for obj in b %}{% for itm in obj %}({{ itm[0] }},{{ itm[1] }}), {% endfor %}{% endfor %}",
-      "data": {
-        "h": {
-          "foo": 1,
-          "bar": 2,
-          "baz": 3
-        }
-      },
-      "result": "(foo,1), (bar,2), (baz,3), ",
       "tags": [
         "assign tag",
         "for tag",
@@ -4685,6 +4608,23 @@
       ]
     },
     {
+      "name": "filters, reject, input is a hash, default value, no match",
+      "template": "{% assign b = h | reject: 'barbar' %}{% for obj in b %}{% for itm in obj %}({{ itm[0] }},{{ itm[1] }}), {% endfor %}{% endfor %}",
+      "data": {
+        "h": {
+          "foo": 1,
+          "bar": 2,
+          "baz": 3
+        }
+      },
+      "result": "(foo,1), (bar,2), (baz,3), ",
+      "tags": [
+        "assign tag",
+        "for tag",
+        "reject filter"
+      ]
+    },
+    {
       "name": "filters, reject, input is a hash, explicit nil match",
       "template": "{% assign b = h | reject: 'bar', nil %}{% for obj in b %}{% for itm in obj %}({{ itm[0] }},{{ itm[1] }}), {% endfor %}{% endfor %}",
       "data": {
@@ -4695,6 +4635,23 @@
         }
       },
       "result": "(foo,1), (bar,), (baz,3), ",
+      "tags": [
+        "assign tag",
+        "for tag",
+        "reject filter"
+      ]
+    },
+    {
+      "name": "filters, reject, input is a hash, int value, match",
+      "template": "{% assign b = h | reject: 'bar', 2 %}{% for obj in b %}{% for itm in obj %}({{ itm[0] }},{{ itm[1] }}), {% endfor %}{% endfor %}",
+      "data": {
+        "h": {
+          "foo": 1,
+          "bar": 2,
+          "baz": 3
+        }
+      },
+      "result": "",
       "tags": [
         "assign tag",
         "for tag",
@@ -4719,16 +4676,26 @@
       ]
     },
     {
-      "name": "filters, reject, input is a hash, int value, match",
-      "template": "{% assign b = h | reject: 'bar', 2 %}{% for obj in b %}{% for itm in obj %}({{ itm[0] }},{{ itm[1] }}), {% endfor %}{% endfor %}",
-      "data": {
-        "h": {
-          "foo": 1,
-          "bar": 2,
-          "baz": 3
-        }
-      },
+      "name": "filters, reject, input is undefined",
+      "template": "{% assign b = nosuchthing | reject: 'c' %}{% for obj in b %}{{ obj }}, {% endfor %}",
       "result": "",
+      "tags": [
+        "assign tag",
+        "for tag",
+        "reject filter"
+      ]
+    },
+    {
+      "name": "filters, reject, missing argument",
+      "template": "{% assign b = a | reject %}{% for obj in b %}{{ obj }}, {% endfor %}",
+      "data": {
+        "a": [
+          "x",
+          "y",
+          "cat"
+        ]
+      },
+      "invalid": true,
       "tags": [
         "assign tag",
         "for tag",
@@ -4765,12 +4732,22 @@
       ]
     },
     {
-      "name": "filters, reject, string input becomes a single element array, substring match",
-      "template": "{% assign b = s | reject: 'oo' %}{% for obj in b %}{{ obj }}, {% endfor %}",
+      "name": "filters, reject, second argument is undefined",
+      "template": "{% assign b = a | reject: 'title', nosuchthing %}{% for obj in b %}{% for itm in obj %}({{ itm[0] }},{{ itm[1] }}), {% endfor %}{% endfor %}",
       "data": {
-        "s": "foobar"
+        "a": [
+          {
+            "title": "foo"
+          },
+          {
+            "title": "bar"
+          },
+          {
+            "title": null
+          }
+        ]
       },
-      "result": "",
+      "result": "(title,), ",
       "tags": [
         "assign tag",
         "for tag",
@@ -4791,19 +4768,26 @@
       ]
     },
     {
-      "name": "filters, remove, remove substrings",
-      "template": "{{ \"I strained to see the train through the rain\" | remove: \"rain\" }}",
-      "result": "I sted to see the t through the ",
+      "name": "filters, reject, string input becomes a single element array, substring match",
+      "template": "{% assign b = s | reject: 'oo' %}{% for obj in b %}{{ obj }}, {% endfor %}",
+      "data": {
+        "s": "foobar"
+      },
+      "result": "",
       "tags": [
-        "remove filter"
+        "assign tag",
+        "for tag",
+        "reject filter"
       ]
     },
     {
-      "name": "filters, remove, not a string",
-      "template": "{{ 5 | remove: 'there' }}",
-      "result": "5",
+      "name": "filters, reject, too many arguments",
+      "template": "{% assign b = a | reject: 'x', 'y', 'z' %}{% for obj in b %}{{ obj }}, {% endfor %}",
+      "invalid": true,
       "tags": [
-        "remove filter"
+        "assign tag",
+        "for tag",
+        "reject filter"
       ]
     },
     {
@@ -4823,17 +4807,25 @@
       ]
     },
     {
-      "name": "filters, remove, too many arguments",
-      "template": "{{ \"hello\" | remove: \"how\", \"are\", \"you\" }}",
-      "invalid": true,
+      "name": "filters, remove, not a string",
+      "template": "{{ 5 | remove: 'there' }}",
+      "result": "5",
       "tags": [
         "remove filter"
       ]
     },
     {
-      "name": "filters, remove, undefined left value",
-      "template": "{{ nosuchthing | remove: \"rain\" }}",
-      "result": "",
+      "name": "filters, remove, remove substrings",
+      "template": "{{ \"I strained to see the train through the rain\" | remove: \"rain\" }}",
+      "result": "I sted to see the t through the ",
+      "tags": [
+        "remove filter"
+      ]
+    },
+    {
+      "name": "filters, remove, too many arguments",
+      "template": "{{ \"hello\" | remove: \"how\", \"are\", \"you\" }}",
+      "invalid": true,
       "tags": [
         "remove filter"
       ]
@@ -4847,19 +4839,11 @@
       ]
     },
     {
-      "name": "filters, remove first, remove substrings",
-      "template": "{{ \"I strained to see the train through the rain\" | remove_first: \"rain\" }}",
-      "result": "I sted to see the train through the rain",
+      "name": "filters, remove, undefined left value",
+      "template": "{{ nosuchthing | remove: \"rain\" }}",
+      "result": "",
       "tags": [
-        "remove_first filter"
-      ]
-    },
-    {
-      "name": "filters, remove first, not a string",
-      "template": "{{ 5 | remove_first: 'rain' }}",
-      "result": "5",
-      "tags": [
-        "remove_first filter"
+        "remove filter"
       ]
     },
     {
@@ -4879,17 +4863,25 @@
       ]
     },
     {
-      "name": "filters, remove first, too many arguments",
-      "template": "{{ \"hello\" | remove_first: \"how\", \"are\", \"you\" }}",
-      "invalid": true,
+      "name": "filters, remove first, not a string",
+      "template": "{{ 5 | remove_first: 'rain' }}",
+      "result": "5",
       "tags": [
         "remove_first filter"
       ]
     },
     {
-      "name": "filters, remove first, undefined left value",
-      "template": "{{ nosuchthing | remove_first: \"rain\" }}",
-      "result": "",
+      "name": "filters, remove first, remove substrings",
+      "template": "{{ \"I strained to see the train through the rain\" | remove_first: \"rain\" }}",
+      "result": "I sted to see the train through the rain",
+      "tags": [
+        "remove_first filter"
+      ]
+    },
+    {
+      "name": "filters, remove first, too many arguments",
+      "template": "{{ \"hello\" | remove_first: \"how\", \"are\", \"you\" }}",
+      "invalid": true,
       "tags": [
         "remove_first filter"
       ]
@@ -4903,19 +4895,11 @@
       ]
     },
     {
-      "name": "filters, remove last, remove substrings",
-      "template": "{{ \"I strained to see the train through the rain\" | remove_last: \"rain\" }}",
-      "result": "I strained to see the train through the ",
+      "name": "filters, remove first, undefined left value",
+      "template": "{{ nosuchthing | remove_first: \"rain\" }}",
+      "result": "",
       "tags": [
-        "remove_last filter"
-      ]
-    },
-    {
-      "name": "filters, remove last, not a string",
-      "template": "{{ 5 | remove_last: 'rain' }}",
-      "result": "5",
-      "tags": [
-        "remove_last filter"
+        "remove_first filter"
       ]
     },
     {
@@ -4935,17 +4919,25 @@
       ]
     },
     {
-      "name": "filters, remove last, too many arguments",
-      "template": "{{ \"hello\" | remove_last: \"how\", \"are\", \"you\" }}",
-      "invalid": true,
+      "name": "filters, remove last, not a string",
+      "template": "{{ 5 | remove_last: 'rain' }}",
+      "result": "5",
       "tags": [
         "remove_last filter"
       ]
     },
     {
-      "name": "filters, remove last, undefined left value",
-      "template": "{{ nosuchthing | remove_last: \"rain\" }}",
-      "result": "",
+      "name": "filters, remove last, remove substrings",
+      "template": "{{ \"I strained to see the train through the rain\" | remove_last: \"rain\" }}",
+      "result": "I strained to see the train through the ",
+      "tags": [
+        "remove_last filter"
+      ]
+    },
+    {
+      "name": "filters, remove last, too many arguments",
+      "template": "{{ \"hello\" | remove_last: \"how\", \"are\", \"you\" }}",
+      "invalid": true,
       "tags": [
         "remove_last filter"
       ]
@@ -4959,17 +4951,17 @@
       ]
     },
     {
-      "name": "filters, replace, replace substrings",
-      "template": "{{ \"Take my protein pills and put my helmet on\" | replace: \"my\", \"your\" }}",
-      "result": "Take your protein pills and put your helmet on",
+      "name": "filters, remove last, undefined left value",
+      "template": "{{ nosuchthing | remove_last: \"rain\" }}",
+      "result": "",
       "tags": [
-        "replace filter"
+        "remove_last filter"
       ]
     },
     {
-      "name": "filters, replace, not a string",
-      "template": "{{ 5 | replace: 'rain', 'foo' }}",
-      "result": "5",
+      "name": "filters, replace, argument not a string",
+      "template": "{{ \"hello\" | replace: 5, \"your\" }}",
+      "result": "hello",
       "tags": [
         "replace filter"
       ]
@@ -4981,14 +4973,6 @@
         "a": {}
       },
       "result": "!}",
-      "tags": [
-        "replace filter"
-      ]
-    },
-    {
-      "name": "filters, replace, argument not a string",
-      "template": "{{ \"hello\" | replace: 5, \"your\" }}",
-      "result": "hello",
       "tags": [
         "replace filter"
       ]
@@ -5010,17 +4994,25 @@
       ]
     },
     {
-      "name": "filters, replace, too many arguments",
-      "template": "{{ \"hello\" | replace: \"how\", \"are\", \"you\" }}",
-      "invalid": true,
+      "name": "filters, replace, not a string",
+      "template": "{{ 5 | replace: 'rain', 'foo' }}",
+      "result": "5",
       "tags": [
         "replace filter"
       ]
     },
     {
-      "name": "filters, replace, undefined left value",
-      "template": "{{ nosuchthing | replace: \"my\", \"your\" }}",
-      "result": "",
+      "name": "filters, replace, replace substrings",
+      "template": "{{ \"Take my protein pills and put my helmet on\" | replace: \"my\", \"your\" }}",
+      "result": "Take your protein pills and put your helmet on",
+      "tags": [
+        "replace filter"
+      ]
+    },
+    {
+      "name": "filters, replace, too many arguments",
+      "template": "{{ \"hello\" | replace: \"how\", \"are\", \"you\" }}",
+      "invalid": true,
       "tags": [
         "replace filter"
       ]
@@ -5034,27 +5026,19 @@
       ]
     },
     {
-      "name": "filters, replace, undefined second argument",
-      "template": "{{ \"Take my protein pills and put my helmet on\" | replace: \"my\", nosuchthing }}",
-      "result": "Take  protein pills and put  helmet on",
+      "name": "filters, replace, undefined left value",
+      "template": "{{ nosuchthing | replace: \"my\", \"your\" }}",
+      "result": "",
       "tags": [
         "replace filter"
       ]
     },
     {
-      "name": "filters, replace first, replace substrings",
-      "template": "{{ \"Take my protein pills and put my helmet on\" | replace_first: \"my\", \"your\" }}",
-      "result": "Take your protein pills and put my helmet on",
+      "name": "filters, replace, undefined second argument",
+      "template": "{{ \"Take my protein pills and put my helmet on\" | replace: \"my\", nosuchthing }}",
+      "result": "Take  protein pills and put  helmet on",
       "tags": [
-        "replace_first filter"
-      ]
-    },
-    {
-      "name": "filters, replace first, not a string",
-      "template": "{{ 5 | replace_first: 'rain', 'foo' }}",
-      "result": "5",
-      "tags": [
-        "replace_first filter"
+        "replace filter"
       ]
     },
     {
@@ -5082,17 +5066,25 @@
       ]
     },
     {
-      "name": "filters, replace first, too many arguments",
-      "template": "{{ \"hello\" | replace_first: \"how\", \"are\", \"you\" }}",
-      "invalid": true,
+      "name": "filters, replace first, not a string",
+      "template": "{{ 5 | replace_first: 'rain', 'foo' }}",
+      "result": "5",
       "tags": [
         "replace_first filter"
       ]
     },
     {
-      "name": "filters, replace first, undefined left value",
-      "template": "{{ nosuchthing | replace_first: \"my\", \"your\" }}",
-      "result": "",
+      "name": "filters, replace first, replace substrings",
+      "template": "{{ \"Take my protein pills and put my helmet on\" | replace_first: \"my\", \"your\" }}",
+      "result": "Take your protein pills and put my helmet on",
+      "tags": [
+        "replace_first filter"
+      ]
+    },
+    {
+      "name": "filters, replace first, too many arguments",
+      "template": "{{ \"hello\" | replace_first: \"how\", \"are\", \"you\" }}",
+      "invalid": true,
       "tags": [
         "replace_first filter"
       ]
@@ -5106,27 +5098,19 @@
       ]
     },
     {
-      "name": "filters, replace first, undefined second argument",
-      "template": "{{ \"Take my protein pills and put my helmet on\" | replace_first: \"my\", nosuchthing }}",
-      "result": "Take  protein pills and put my helmet on",
+      "name": "filters, replace first, undefined left value",
+      "template": "{{ nosuchthing | replace_first: \"my\", \"your\" }}",
+      "result": "",
       "tags": [
         "replace_first filter"
       ]
     },
     {
-      "name": "filters, replace last, replace substrings",
-      "template": "{{ \"Take my protein pills and put my helmet on\" | replace_last: \"my\", \"your\" }}",
-      "result": "Take my protein pills and put your helmet on",
+      "name": "filters, replace first, undefined second argument",
+      "template": "{{ \"Take my protein pills and put my helmet on\" | replace_first: \"my\", nosuchthing }}",
+      "result": "Take  protein pills and put my helmet on",
       "tags": [
-        "replace_last filter"
-      ]
-    },
-    {
-      "name": "filters, replace last, not a string",
-      "template": "{{ 5 | replace_last: 'rain', 'foo' }}",
-      "result": "5",
-      "tags": [
-        "replace_last filter"
+        "replace_first filter"
       ]
     },
     {
@@ -5154,6 +5138,22 @@
       ]
     },
     {
+      "name": "filters, replace last, not a string",
+      "template": "{{ 5 | replace_last: 'rain', 'foo' }}",
+      "result": "5",
+      "tags": [
+        "replace_last filter"
+      ]
+    },
+    {
+      "name": "filters, replace last, replace substrings",
+      "template": "{{ \"Take my protein pills and put my helmet on\" | replace_last: \"my\", \"your\" }}",
+      "result": "Take my protein pills and put your helmet on",
+      "tags": [
+        "replace_last filter"
+      ]
+    },
+    {
       "name": "filters, replace last, too many arguments",
       "template": "{{ \"hello\" | replace_last: \"how\", \"are\", \"you\" }}",
       "invalid": true,
@@ -5162,17 +5162,17 @@
       ]
     },
     {
-      "name": "filters, replace last, undefined left value",
-      "template": "{{ nosuchthing | replace_last: \"my\", \"your\" }}",
-      "result": "",
+      "name": "filters, replace last, undefined first argument",
+      "template": "{{ \"Take my protein\" | replace_last: nosuchthing, \"#\" }}",
+      "result": "Take my protein#",
       "tags": [
         "replace_last filter"
       ]
     },
     {
-      "name": "filters, replace last, undefined first argument",
-      "template": "{{ \"Take my protein\" | replace_last: nosuchthing, \"#\" }}",
-      "result": "Take my protein#",
+      "name": "filters, replace last, undefined left value",
+      "template": "{{ nosuchthing | replace_last: \"my\", \"your\" }}",
+      "result": "",
       "tags": [
         "replace_last filter"
       ]
@@ -5233,12 +5233,9 @@
       ]
     },
     {
-      "name": "filters, reverse, unexpected argument",
-      "template": "{{ a | reverse: 0 | join: '#' }}",
-      "data": {
-        "a": []
-      },
-      "invalid": true,
+      "name": "filters, reverse, left value is undefined",
+      "template": "{{ nosuchthing | reverse | join: '#' }}",
+      "result": "",
       "tags": [
         "join filter",
         "reverse filter"
@@ -5257,82 +5254,29 @@
       ]
     },
     {
-      "name": "filters, reverse, left value is undefined",
-      "template": "{{ nosuchthing | reverse | join: '#' }}",
-      "result": "",
+      "name": "filters, reverse, unexpected argument",
+      "template": "{{ a | reverse: 0 | join: '#' }}",
+      "data": {
+        "a": []
+      },
+      "invalid": true,
       "tags": [
         "join filter",
         "reverse filter"
       ]
     },
     {
-      "name": "filters, round, float round down",
-      "template": "{{ 5.1 | round }}",
-      "result": "5",
-      "tags": [
-        "round filter"
-      ]
-    },
-    {
-      "name": "filters, round, float round up",
-      "template": "{{ 5.6 | round }}",
-      "result": "6",
-      "tags": [
-        "round filter"
-      ]
-    },
-    {
-      "name": "filters, round, float as a string",
-      "template": "{{ \"5.6\" | round }}",
-      "result": "6",
-      "tags": [
-        "round filter"
-      ]
-    },
-    {
-      "name": "filters, round, string argument",
-      "template": "{{ 5.666 | round: \"1\" }}",
+      "name": "filters, round, argument is a float",
+      "template": "{{ 5.666 | round: 1.2 }}",
       "result": "5.7",
       "tags": [
         "round filter"
       ]
     },
     {
-      "name": "filters, round, decimal places",
-      "template": "{{ \"5.666666\" | round: 2 }}",
-      "result": "5.67",
-      "tags": [
-        "round filter"
-      ]
-    },
-    {
-      "name": "filters, round, integer",
-      "template": "{{ 5 | round }}",
-      "result": "5",
-      "tags": [
-        "round filter"
-      ]
-    },
-    {
-      "name": "filters, round, too many args",
-      "template": "{{ 5 | round: 1, 2 }}",
-      "invalid": true,
-      "tags": [
-        "round filter"
-      ]
-    },
-    {
-      "name": "filters, round, undefined left value",
-      "template": "{{ nosuchthing | round: 2 }}",
+      "name": "filters, round, argument is a negative",
+      "template": "{{ 5.666 | round: -2 }}",
       "result": "0",
-      "tags": [
-        "round filter"
-      ]
-    },
-    {
-      "name": "filters, round, undefined argument",
-      "template": "{{ 5.666 | round: nosuchthing }}",
-      "result": "6",
       "tags": [
         "round filter"
       ]
@@ -5362,22 +5306,6 @@
       ]
     },
     {
-      "name": "filters, round, argument is a negative",
-      "template": "{{ 5.666 | round: -2 }}",
-      "result": "0",
-      "tags": [
-        "round filter"
-      ]
-    },
-    {
-      "name": "filters, round, argument is a float",
-      "template": "{{ 5.666 | round: 1.2 }}",
-      "result": "5.7",
-      "tags": [
-        "round filter"
-      ]
-    },
-    {
       "name": "filters, round, argument is a zero",
       "template": "{{ 5.666 | round: 0 }}",
       "result": "6",
@@ -5386,24 +5314,88 @@
       ]
     },
     {
-      "name": "filters, rstrip, left padded",
-      "template": "{{ \" \t\r\n  hello\" | rstrip }}",
+      "name": "filters, round, decimal places",
+      "template": "{{ \"5.666666\" | round: 2 }}",
+      "result": "5.67",
+      "tags": [
+        "round filter"
+      ]
+    },
+    {
+      "name": "filters, round, float as a string",
+      "template": "{{ \"5.6\" | round }}",
+      "result": "6",
+      "tags": [
+        "round filter"
+      ]
+    },
+    {
+      "name": "filters, round, float round down",
+      "template": "{{ 5.1 | round }}",
+      "result": "5",
+      "tags": [
+        "round filter"
+      ]
+    },
+    {
+      "name": "filters, round, float round up",
+      "template": "{{ 5.6 | round }}",
+      "result": "6",
+      "tags": [
+        "round filter"
+      ]
+    },
+    {
+      "name": "filters, round, integer",
+      "template": "{{ 5 | round }}",
+      "result": "5",
+      "tags": [
+        "round filter"
+      ]
+    },
+    {
+      "name": "filters, round, string argument",
+      "template": "{{ 5.666 | round: \"1\" }}",
+      "result": "5.7",
+      "tags": [
+        "round filter"
+      ]
+    },
+    {
+      "name": "filters, round, too many args",
+      "template": "{{ 5 | round: 1, 2 }}",
+      "invalid": true,
+      "tags": [
+        "round filter"
+      ]
+    },
+    {
+      "name": "filters, round, undefined argument",
+      "template": "{{ 5.666 | round: nosuchthing }}",
+      "result": "6",
+      "tags": [
+        "round filter"
+      ]
+    },
+    {
+      "name": "filters, round, undefined left value",
+      "template": "{{ nosuchthing | round: 2 }}",
+      "result": "0",
+      "tags": [
+        "round filter"
+      ]
+    },
+    {
+      "name": "filters, rstrip, left and right padded",
+      "template": "{{ \" \t\r\n  hello  \t\r\n \" | rstrip }}",
       "result": " \t\r\n  hello",
       "tags": [
         "rstrip filter"
       ]
     },
     {
-      "name": "filters, rstrip, right padded",
-      "template": "{{ \"hello \t\r\n  \" | rstrip }}",
-      "result": "hello",
-      "tags": [
-        "rstrip filter"
-      ]
-    },
-    {
-      "name": "filters, rstrip, left and right padded",
-      "template": "{{ \" \t\r\n  hello  \t\r\n \" | rstrip }}",
+      "name": "filters, rstrip, left padded",
+      "template": "{{ \" \t\r\n  hello\" | rstrip }}",
       "result": " \t\r\n  hello",
       "tags": [
         "rstrip filter"
@@ -5418,9 +5410,9 @@
       ]
     },
     {
-      "name": "filters, rstrip, unexpected argument",
-      "template": "{{ \"hello\" | rstrip: 5 }}",
-      "invalid": true,
+      "name": "filters, rstrip, right padded",
+      "template": "{{ \"hello \t\r\n  \" | rstrip }}",
+      "result": "hello",
       "tags": [
         "rstrip filter"
       ]
@@ -5431,6 +5423,39 @@
       "result": "",
       "tags": [
         "rstrip filter"
+      ]
+    },
+    {
+      "name": "filters, rstrip, unexpected argument",
+      "template": "{{ \"hello\" | rstrip: 5 }}",
+      "invalid": true,
+      "tags": [
+        "rstrip filter"
+      ]
+    },
+    {
+      "name": "filters, size, size of a hash",
+      "template": "{{ a | size }}",
+      "data": {
+        "a": {
+          "a": 1,
+          "b": 2
+        }
+      },
+      "result": "2",
+      "tags": [
+        "size filter"
+      ]
+    },
+    {
+      "name": "filters, size, size of a string",
+      "template": "{{ a | size }}",
+      "data": {
+        "a": "abc"
+      },
+      "result": "3",
+      "tags": [
+        "size filter"
       ]
     },
     {
@@ -5449,17 +5474,6 @@
       ]
     },
     {
-      "name": "filters, size, size of a string",
-      "template": "{{ a | size }}",
-      "data": {
-        "a": "abc"
-      },
-      "result": "3",
-      "tags": [
-        "size filter"
-      ]
-    },
-    {
       "name": "filters, size, size of an empty array",
       "template": "{{ a | size }}",
       "data": {
@@ -5471,15 +5485,9 @@
       ]
     },
     {
-      "name": "filters, size, size of a hash",
-      "template": "{{ a | size }}",
-      "data": {
-        "a": {
-          "a": 1,
-          "b": 2
-        }
-      },
-      "result": "2",
+      "name": "filters, size, undefined left value",
+      "template": "{{ nosuchthing | size }}",
+      "result": "0",
       "tags": [
         "size filter"
       ]
@@ -5500,17 +5508,73 @@
       ]
     },
     {
-      "name": "filters, size, undefined left value",
-      "template": "{{ nosuchthing | size }}",
-      "result": "0",
+      "name": "filters, slice, first argument is a float",
+      "template": "{{ 'Liquid' | slice: 2.2 }}",
+      "invalid": true,
       "tags": [
-        "size filter"
+        "slice filter"
       ]
     },
     {
-      "name": "filters, slice, zero",
-      "template": "{{ \"hello\" | slice: 0 }}",
-      "result": "h",
+      "name": "filters, slice, first argument is a string",
+      "template": "{{ \"hello\" | slice: \"2\" }}",
+      "result": "l",
+      "tags": [
+        "slice filter"
+      ]
+    },
+    {
+      "name": "filters, slice, first argument not an integer",
+      "template": "{{ \"hello\" | slice: \"foo\" }}",
+      "invalid": true,
+      "tags": [
+        "slice filter"
+      ]
+    },
+    {
+      "name": "filters, slice, missing arguments",
+      "template": "{{ \"hello\" | slice }}",
+      "invalid": true,
+      "tags": [
+        "slice filter"
+      ]
+    },
+    {
+      "name": "filters, slice, negative first argument",
+      "template": "{{ 'Liquid' | slice: -2 }}",
+      "result": "i",
+      "tags": [
+        "slice filter"
+      ]
+    },
+    {
+      "name": "filters, slice, negative first argument and length out of range",
+      "template": "{{ 'Liquid' | slice: -2, 99 }}",
+      "result": "id",
+      "tags": [
+        "slice filter"
+      ]
+    },
+    {
+      "name": "filters, slice, negative first argument and negative length",
+      "template": "{{ 'Liquid' | slice: -2, -1 }}",
+      "result": "",
+      "tags": [
+        "slice filter"
+      ]
+    },
+    {
+      "name": "filters, slice, negative first argument and positive length",
+      "template": "{{ 'Liquid' | slice: -2, 2 }}",
+      "result": "id",
+      "tags": [
+        "slice filter"
+      ]
+    },
+    {
+      "name": "filters, slice, not a string",
+      "template": "{{ 5 | slice: 1 }}",
+      "result": "",
       "tags": [
         "slice filter"
       ]
@@ -5540,32 +5604,8 @@
       ]
     },
     {
-      "name": "filters, slice, not a string",
-      "template": "{{ 5 | slice: 1 }}",
-      "result": "",
-      "tags": [
-        "slice filter"
-      ]
-    },
-    {
-      "name": "filters, slice, first argument is a string",
-      "template": "{{ \"hello\" | slice: \"2\" }}",
-      "result": "l",
-      "tags": [
-        "slice filter"
-      ]
-    },
-    {
-      "name": "filters, slice, first argument not an integer",
-      "template": "{{ \"hello\" | slice: \"foo\" }}",
-      "invalid": true,
-      "tags": [
-        "slice filter"
-      ]
-    },
-    {
-      "name": "filters, slice, second argument not an integer",
-      "template": "{{ \"hello\" | slice: 5, \"foo\" }}",
+      "name": "filters, slice, second argument is a float",
+      "template": "{{ 'Liquid' | slice: 1, 2.2 }}",
       "invalid": true,
       "tags": [
         "slice filter"
@@ -5580,41 +5620,9 @@
       ]
     },
     {
-      "name": "filters, slice, missing arguments",
-      "template": "{{ \"hello\" | slice }}",
+      "name": "filters, slice, second argument not an integer",
+      "template": "{{ \"hello\" | slice: 5, \"foo\" }}",
       "invalid": true,
-      "tags": [
-        "slice filter"
-      ]
-    },
-    {
-      "name": "filters, slice, too many arguments",
-      "template": "{{ \"hello\" | slice: 1, 2, 3 }}",
-      "invalid": true,
-      "tags": [
-        "slice filter"
-      ]
-    },
-    {
-      "name": "filters, slice, undefined left value",
-      "template": "{{ nosuchthing | slice: 1, 3 }}",
-      "result": "",
-      "tags": [
-        "slice filter"
-      ]
-    },
-    {
-      "name": "filters, slice, undefined first argument",
-      "template": "{{ \"hello\" | slice: nosuchthing, 3 }}",
-      "invalid": true,
-      "tags": [
-        "slice filter"
-      ]
-    },
-    {
-      "name": "filters, slice, undefined second argument",
-      "template": "{{ \"hello\" | slice: 1, nosuchthing }}",
-      "result": "e",
       "tags": [
         "slice filter"
       ]
@@ -5638,66 +5646,72 @@
       ]
     },
     {
-      "name": "filters, slice, first argument is a float",
-      "template": "{{ 'Liquid' | slice: 2.2 }}",
+      "name": "filters, slice, too many arguments",
+      "template": "{{ \"hello\" | slice: 1, 2, 3 }}",
       "invalid": true,
       "tags": [
         "slice filter"
       ]
     },
     {
-      "name": "filters, slice, second argument is a float",
-      "template": "{{ 'Liquid' | slice: 1, 2.2 }}",
+      "name": "filters, slice, undefined first argument",
+      "template": "{{ \"hello\" | slice: nosuchthing, 3 }}",
       "invalid": true,
       "tags": [
         "slice filter"
       ]
     },
     {
-      "name": "filters, slice, negative first argument",
-      "template": "{{ 'Liquid' | slice: -2 }}",
-      "result": "i",
-      "tags": [
-        "slice filter"
-      ]
-    },
-    {
-      "name": "filters, slice, negative first argument and positive length",
-      "template": "{{ 'Liquid' | slice: -2, 2 }}",
-      "result": "id",
-      "tags": [
-        "slice filter"
-      ]
-    },
-    {
-      "name": "filters, slice, negative first argument and negative length",
-      "template": "{{ 'Liquid' | slice: -2, -1 }}",
+      "name": "filters, slice, undefined left value",
+      "template": "{{ nosuchthing | slice: 1, 3 }}",
       "result": "",
       "tags": [
         "slice filter"
       ]
     },
     {
-      "name": "filters, slice, negative first argument and length out of range",
-      "template": "{{ 'Liquid' | slice: -2, 99 }}",
-      "result": "id",
+      "name": "filters, slice, undefined second argument",
+      "template": "{{ \"hello\" | slice: 1, nosuchthing }}",
+      "result": "e",
       "tags": [
         "slice filter"
       ]
     },
     {
-      "name": "filters, sort, array of strings",
-      "template": "{{ a | sort | join: '#' }}",
+      "name": "filters, slice, zero",
+      "template": "{{ \"hello\" | slice: 0 }}",
+      "result": "h",
+      "tags": [
+        "slice filter"
+      ]
+    },
+    {
+      "name": "filters, sort, argument is undefined",
+      "template": "{{ a | sort: nosuchthing | join: '#' }}",
       "data": {
         "a": [
           "b",
-          "a",
-          "C",
-          "B",
-          "A"
+          "a"
         ]
       },
-      "result": "A#B#C#a#b",
+      "result": "a#b",
+      "tags": [
+        "join filter",
+        "sort filter"
+      ]
+    },
+    {
+      "name": "filters, sort, array of integers",
+      "template": "{{ a | sort | join: '#' }}",
+      "data": {
+        "a": [
+          1,
+          1000,
+          3,
+          30
+        ]
+      },
+      "result": "1#3#30#1000",
       "tags": [
         "join filter",
         "sort filter"
@@ -5750,6 +5764,24 @@
       ]
     },
     {
+      "name": "filters, sort, array of strings",
+      "template": "{{ a | sort | join: '#' }}",
+      "data": {
+        "a": [
+          "b",
+          "a",
+          "C",
+          "B",
+          "A"
+        ]
+      },
+      "result": "A#B#C#a#b",
+      "tags": [
+        "join filter",
+        "sort filter"
+      ]
+    },
+    {
       "name": "filters, sort, empty array",
       "template": "{{ a | sort | join: '#' }}",
       "data": {
@@ -5762,17 +5794,18 @@
       ]
     },
     {
-      "name": "filters, sort, too many arguments",
-      "template": "{{ a | sort: 'title', 'foo' | join: '#' }}",
+      "name": "filters, sort, incompatible types",
+      "template": "{{ a | sort }}",
       "data": {
         "a": [
-          "b",
-          "a"
+          [],
+          {},
+          1,
+          "4"
         ]
       },
       "invalid": true,
       "tags": [
-        "join filter",
         "sort filter"
       ]
     },
@@ -5798,21 +5831,6 @@
       ]
     },
     {
-      "name": "filters, sort, argument is undefined",
-      "template": "{{ a | sort: nosuchthing | join: '#' }}",
-      "data": {
-        "a": [
-          "b",
-          "a"
-        ]
-      },
-      "result": "a#b",
-      "tags": [
-        "join filter",
-        "sort filter"
-      ]
-    },
-    {
       "name": "filters, sort, sort a string",
       "template": "{{ 'BzAa4' | sort | join: '#' }}",
       "result": "BzAa4",
@@ -5822,75 +5840,41 @@
       ]
     },
     {
-      "name": "filters, sort, array of integers",
-      "template": "{{ a | sort | join: '#' }}",
+      "name": "filters, sort, too many arguments",
+      "template": "{{ a | sort: 'title', 'foo' | join: '#' }}",
       "data": {
         "a": [
-          1,
-          1000,
-          3,
-          30
-        ]
-      },
-      "result": "1#3#30#1000",
-      "tags": [
-        "join filter",
-        "sort filter"
-      ]
-    },
-    {
-      "name": "filters, sort, incompatible types",
-      "template": "{{ a | sort }}",
-      "data": {
-        "a": [
-          [],
-          {},
-          1,
-          "4"
+          "b",
+          "a"
         ]
       },
       "invalid": true,
       "tags": [
+        "join filter",
         "sort filter"
       ]
     },
     {
-      "name": "filters, sort natural, array of strings",
-      "template": "{{ a | sort_natural | join: '#' }}",
+      "name": "filters, sort natural, argument is undefined",
+      "template": "{% assign x = a | sort_natural: nosuchthing %}{% for obj in x %}{% for i in obj %}({{ i[0] }},{{ i[1] }}){% endfor %}{% endfor %}",
       "data": {
         "a": [
-          "b",
-          "a",
-          "C",
-          "B",
-          "A"
+          {
+            "title": "foo"
+          },
+          {
+            "title": "bar"
+          },
+          {
+            "title": "Baz"
+          }
         ]
       },
-      "result": "a#A#b#B#C",
-      "tags": [
-        "join filter",
-        "sort_natural filter"
-      ]
-    },
-    {
-      "name": "filters, sort natural, array of strings with a nul",
-      "template": "{% assign x = a | sort_natural %}{% for i in x %}{{ i }}{% unless forloop.last %}#{% endunless %}{% endfor %}",
-      "data": {
-        "a": [
-          "b",
-          "a",
-          null,
-          "C",
-          "B",
-          "A"
-        ]
-      },
-      "result": "a#A#b#B#C#",
+      "result": "(title,bar)(title,Baz)(title,foo)",
       "tags": [
         "assign tag",
         "for tag",
-        "sort_natural filter",
-        "unless tag"
+        "sort_natural filter"
       ]
     },
     {
@@ -5963,26 +5947,42 @@
       ]
     },
     {
-      "name": "filters, sort natural, argument is undefined",
-      "template": "{% assign x = a | sort_natural: nosuchthing %}{% for obj in x %}{% for i in obj %}({{ i[0] }},{{ i[1] }}){% endfor %}{% endfor %}",
+      "name": "filters, sort natural, array of strings",
+      "template": "{{ a | sort_natural | join: '#' }}",
       "data": {
         "a": [
-          {
-            "title": "foo"
-          },
-          {
-            "title": "bar"
-          },
-          {
-            "title": "Baz"
-          }
+          "b",
+          "a",
+          "C",
+          "B",
+          "A"
         ]
       },
-      "result": "(title,bar)(title,Baz)(title,foo)",
+      "result": "a#A#b#B#C",
+      "tags": [
+        "join filter",
+        "sort_natural filter"
+      ]
+    },
+    {
+      "name": "filters, sort natural, array of strings with a nul",
+      "template": "{% assign x = a | sort_natural %}{% for i in x %}{{ i }}{% unless forloop.last %}#{% endunless %}{% endfor %}",
+      "data": {
+        "a": [
+          "b",
+          "a",
+          null,
+          "C",
+          "B",
+          "A"
+        ]
+      },
+      "result": "a#A#b#B#C#",
       "tags": [
         "assign tag",
         "for tag",
-        "sort_natural filter"
+        "sort_natural filter",
+        "unless tag"
       ]
     },
     {
@@ -5997,6 +5997,21 @@
         "for tag",
         "sort_natural filter",
         "unless tag"
+      ]
+    },
+    {
+      "name": "filters, sort natural, incompatible types",
+      "template": "{{ a | sort_natural }}",
+      "data": {
+        "a": [
+          {},
+          1,
+          "4"
+        ]
+      },
+      "result": "14{}",
+      "tags": [
+        "sort_natural filter"
       ]
     },
     {
@@ -6019,115 +6034,12 @@
       ]
     },
     {
-      "name": "filters, sort natural, incompatible types",
-      "template": "{{ a | sort_natural }}",
-      "data": {
-        "a": [
-          {},
-          1,
-          "4"
-        ]
-      },
-      "result": "14{}",
-      "tags": [
-        "sort_natural filter"
-      ]
-    },
-    {
-      "name": "filters, split, split string",
-      "template": "{{ \"Hi, how are you today?\" | split: \" \" | join: \"#\" }}",
-      "result": "Hi,#how#are#you#today?",
-      "tags": [
-        "join filter",
-        "split filter"
-      ]
-    },
-    {
-      "name": "filters, split, not a string",
-      "template": "{{ 56 | split: ' ' | first }}",
-      "result": "56",
-      "tags": [
-        "first filter",
-        "split filter"
-      ]
-    },
-    {
-      "name": "filters, split, argument not a string",
-      "template": "{{ \"hello th1ere\" | split: 1 | join: \"#\" }}",
-      "result": "hello th#ere",
-      "tags": [
-        "join filter",
-        "split filter"
-      ]
-    },
-    {
-      "name": "filters, split, missing argument",
-      "template": "{{ \"hello there\" | split }}",
-      "invalid": true,
-      "tags": [
-        "split filter"
-      ]
-    },
-    {
-      "name": "filters, split, too many arguments",
-      "template": "{{ \"hello there\" | split: \" \", \",\" }}",
-      "invalid": true,
-      "tags": [
-        "split filter"
-      ]
-    },
-    {
-      "name": "filters, split, undefined left value",
-      "template": "{{ nosuchthing | split: \" \" }}",
-      "result": "",
-      "tags": [
-        "split filter"
-      ]
-    },
-    {
-      "name": "filters, split, undefined argument",
-      "template": "{{ \"Hello there\" | split: nosuchthing | join: \"#\" }}",
-      "result": "H#e#l#l#o# #t#h#e#r#e",
-      "tags": [
-        "join filter",
-        "split filter"
-      ]
-    },
-    {
-      "name": "filters, split, empty string argument",
-      "template": "{% assign a = \"abc\" | split: \"\" %}{% for i in a %}#{{ forloop.index0 }}{{ i }}{% endfor %}",
-      "result": "#0a#1b#2c",
+      "name": "filters, split, argument does not appear in string",
+      "template": "{% assign a = \"abc\" | split: \",\" %}{% for i in a %}#{{ forloop.index0 }}{{ i }}{% endfor %}",
+      "result": "#0abc",
       "tags": [
         "assign tag",
         "for tag",
-        "split filter"
-      ]
-    },
-    {
-      "name": "filters, split, argument is a single space",
-      "template": "{% assign a = \"a b\nc\" | split: \" \" %}{% for i in a %}#{{ forloop.index0 }}{{ i }}{% endfor %}",
-      "result": "#0a#1b#2c",
-      "tags": [
-        "assign tag",
-        "for tag",
-        "split filter"
-      ]
-    },
-    {
-      "name": "filters, split, argument is nil",
-      "template": "{{ \"Hello there\" | split: nil | join: \"#\" }}",
-      "result": "H#e#l#l#o# #t#h#e#r#e",
-      "tags": [
-        "join filter",
-        "split filter"
-      ]
-    },
-    {
-      "name": "filters, split, argument is false",
-      "template": "{{ \"Hello there\" | split: false | join: \"#\" }}",
-      "result": "Hello there",
-      "tags": [
-        "join filter",
         "split filter"
       ]
     },
@@ -6145,12 +6057,39 @@
       ]
     },
     {
-      "name": "filters, split, argument does not appear in string",
-      "template": "{% assign a = \"abc\" | split: \",\" %}{% for i in a %}#{{ forloop.index0 }}{{ i }}{% endfor %}",
-      "result": "#0abc",
+      "name": "filters, split, argument is a single space",
+      "template": "{% assign a = \"a b\nc\" | split: \" \" %}{% for i in a %}#{{ forloop.index0 }}{{ i }}{% endfor %}",
+      "result": "#0a#1b#2c",
       "tags": [
         "assign tag",
         "for tag",
+        "split filter"
+      ]
+    },
+    {
+      "name": "filters, split, argument is false",
+      "template": "{{ \"Hello there\" | split: false | join: \"#\" }}",
+      "result": "Hello there",
+      "tags": [
+        "join filter",
+        "split filter"
+      ]
+    },
+    {
+      "name": "filters, split, argument is nil",
+      "template": "{{ \"Hello there\" | split: nil | join: \"#\" }}",
+      "result": "H#e#l#l#o# #t#h#e#r#e",
+      "tags": [
+        "join filter",
+        "split filter"
+      ]
+    },
+    {
+      "name": "filters, split, argument not a string",
+      "template": "{{ \"hello th1ere\" | split: 1 | join: \"#\" }}",
+      "result": "hello th#ere",
+      "tags": [
+        "join filter",
         "split filter"
       ]
     },
@@ -6168,6 +6107,16 @@
       "name": "filters, split, empty string and single char argument",
       "template": "{% assign a = \"\" | split: \",\" %}{% for i in a %}{{ forloop.index0 }}{{ i }}{% endfor %}",
       "result": "",
+      "tags": [
+        "assign tag",
+        "for tag",
+        "split filter"
+      ]
+    },
+    {
+      "name": "filters, split, empty string argument",
+      "template": "{% assign a = \"abc\" | split: \"\" %}{% for i in a %}#{{ forloop.index0 }}{{ i }}{% endfor %}",
+      "result": "#0a#1b#2c",
       "tags": [
         "assign tag",
         "for tag",
@@ -6195,24 +6144,67 @@
       ]
     },
     {
-      "name": "filters, strip, left padded",
-      "template": "{{ \" \t\r\n  hello\" | strip }}",
-      "result": "hello",
+      "name": "filters, split, missing argument",
+      "template": "{{ \"hello there\" | split }}",
+      "invalid": true,
       "tags": [
-        "strip filter"
+        "split filter"
       ]
     },
     {
-      "name": "filters, strip, right padded",
-      "template": "{{ \"hello \t\r\n  \" | strip }}",
-      "result": "hello",
+      "name": "filters, split, not a string",
+      "template": "{{ 56 | split: ' ' | first }}",
+      "result": "56",
       "tags": [
-        "strip filter"
+        "first filter",
+        "split filter"
+      ]
+    },
+    {
+      "name": "filters, split, split string",
+      "template": "{{ \"Hi, how are you today?\" | split: \" \" | join: \"#\" }}",
+      "result": "Hi,#how#are#you#today?",
+      "tags": [
+        "join filter",
+        "split filter"
+      ]
+    },
+    {
+      "name": "filters, split, too many arguments",
+      "template": "{{ \"hello there\" | split: \" \", \",\" }}",
+      "invalid": true,
+      "tags": [
+        "split filter"
+      ]
+    },
+    {
+      "name": "filters, split, undefined argument",
+      "template": "{{ \"Hello there\" | split: nosuchthing | join: \"#\" }}",
+      "result": "H#e#l#l#o# #t#h#e#r#e",
+      "tags": [
+        "join filter",
+        "split filter"
+      ]
+    },
+    {
+      "name": "filters, split, undefined left value",
+      "template": "{{ nosuchthing | split: \" \" }}",
+      "result": "",
+      "tags": [
+        "split filter"
       ]
     },
     {
       "name": "filters, strip, left and right padded",
       "template": "{{ \" \t\r\n  hello  \t\r\n \" | strip }}",
+      "result": "hello",
+      "tags": [
+        "strip filter"
+      ]
+    },
+    {
+      "name": "filters, strip, left padded",
+      "template": "{{ \" \t\r\n  hello\" | strip }}",
       "result": "hello",
       "tags": [
         "strip filter"
@@ -6227,9 +6219,9 @@
       ]
     },
     {
-      "name": "filters, strip, unexpected argument",
-      "template": "{{ \"hello\" | strip: 5 }}",
-      "invalid": true,
+      "name": "filters, strip, right padded",
+      "template": "{{ \"hello \t\r\n  \" | strip }}",
+      "result": "hello",
       "tags": [
         "strip filter"
       ]
@@ -6243,49 +6235,11 @@
       ]
     },
     {
-      "name": "filters, strip html, some HTML markup",
-      "template": "{{ s | strip_html }}",
-      "data": {
-        "s": "Have <em>you</em> read <strong>Ulysses</strong> &amp; &#20;?"
-      },
-      "result": "Have you read Ulysses &amp; &#20;?",
-      "tags": [
-        "strip_html filter"
-      ]
-    },
-    {
-      "name": "filters, strip html, some HTML markup with HTML comment",
-      "template": "{{ s | strip_html }}",
-      "data": {
-        "s": "<!-- Have --><em>you</em> read <strong>Ulysses</strong> &amp; &#20;?"
-      },
-      "result": "you read Ulysses &amp; &#20;?",
-      "tags": [
-        "strip_html filter"
-      ]
-    },
-    {
-      "name": "filters, strip html, not a string",
-      "template": "{{ 5 | strip_html }}",
-      "result": "5",
-      "tags": [
-        "strip_html filter"
-      ]
-    },
-    {
-      "name": "filters, strip html, unexpected argument",
-      "template": "{{ \"hello\" | strip_html: 5 }}",
+      "name": "filters, strip, unexpected argument",
+      "template": "{{ \"hello\" | strip: 5 }}",
       "invalid": true,
       "tags": [
-        "strip_html filter"
-      ]
-    },
-    {
-      "name": "filters, strip html, undefined left value",
-      "template": "{{ nosuchthing | strip_html }}",
-      "result": "",
-      "tags": [
-        "strip_html filter"
+        "strip filter"
       ]
     },
     {
@@ -6306,28 +6260,6 @@
         "s": "<div id='test'>test</div>"
       },
       "result": "test",
-      "tags": [
-        "strip_html filter"
-      ]
-    },
-    {
-      "name": "filters, strip html, script block",
-      "template": "{{ s | strip_html }}",
-      "data": {
-        "s": "<script type='text/javascript'>document.write('some stuff');</script>"
-      },
-      "result": "",
-      "tags": [
-        "strip_html filter"
-      ]
-    },
-    {
-      "name": "filters, strip html, style block",
-      "template": "{{ s | strip_html }}",
-      "data": {
-        "s": "<style type='text/css'>foo bar</style>"
-      },
-      "result": "",
       "tags": [
         "strip_html filter"
       ]
@@ -6355,6 +6287,74 @@
       ]
     },
     {
+      "name": "filters, strip html, not a string",
+      "template": "{{ 5 | strip_html }}",
+      "result": "5",
+      "tags": [
+        "strip_html filter"
+      ]
+    },
+    {
+      "name": "filters, strip html, script block",
+      "template": "{{ s | strip_html }}",
+      "data": {
+        "s": "<script type='text/javascript'>document.write('some stuff');</script>"
+      },
+      "result": "",
+      "tags": [
+        "strip_html filter"
+      ]
+    },
+    {
+      "name": "filters, strip html, some HTML markup",
+      "template": "{{ s | strip_html }}",
+      "data": {
+        "s": "Have <em>you</em> read <strong>Ulysses</strong> &amp; &#20;?"
+      },
+      "result": "Have you read Ulysses &amp; &#20;?",
+      "tags": [
+        "strip_html filter"
+      ]
+    },
+    {
+      "name": "filters, strip html, some HTML markup with HTML comment",
+      "template": "{{ s | strip_html }}",
+      "data": {
+        "s": "<!-- Have --><em>you</em> read <strong>Ulysses</strong> &amp; &#20;?"
+      },
+      "result": "you read Ulysses &amp; &#20;?",
+      "tags": [
+        "strip_html filter"
+      ]
+    },
+    {
+      "name": "filters, strip html, style block",
+      "template": "{{ s | strip_html }}",
+      "data": {
+        "s": "<style type='text/css'>foo bar</style>"
+      },
+      "result": "",
+      "tags": [
+        "strip_html filter"
+      ]
+    },
+    {
+      "name": "filters, strip html, undefined left value",
+      "template": "{{ nosuchthing | strip_html }}",
+      "result": "",
+      "tags": [
+        "strip_html filter"
+      ]
+    },
+    {
+      "name": "filters, strip html, unexpected argument",
+      "template": "{{ \"hello\" | strip_html: 5 }}",
+      "invalid": true,
+      "tags": [
+        "strip_html filter"
+      ]
+    },
+    {
       "name": "filters, strip newlines, newline and other whitespace",
       "template": "{{ \"hello there\nyou\" | strip_newlines }}",
       "result": "hello thereyou",
@@ -6366,14 +6366,6 @@
       "name": "filters, strip newlines, not a string",
       "template": "{{ 5 | strip_newlines }}",
       "result": "5",
-      "tags": [
-        "strip_newlines filter"
-      ]
-    },
-    {
-      "name": "filters, strip newlines, unexpected argument",
-      "template": "{{ \"hello\" | strip_newlines: 5 }}",
-      "invalid": true,
       "tags": [
         "strip_newlines filter"
       ]
@@ -6403,6 +6395,14 @@
       ]
     },
     {
+      "name": "filters, strip newlines, unexpected argument",
+      "template": "{{ \"hello\" | strip_newlines: 5 }}",
+      "invalid": true,
+      "tags": [
+        "strip_newlines filter"
+      ]
+    },
+    {
       "name": "filters, sum, empty sequence",
       "template": "{{ a | sum }}",
       "data": {
@@ -6414,13 +6414,82 @@
       ]
     },
     {
-      "name": "filters, sum, only zeros",
+      "name": "filters, sum, hashes with numeric strings and property argument",
+      "template": "{{ a | sum: 'k' }}",
+      "data": {
+        "a": [
+          {
+            "k": "1"
+          },
+          {
+            "k": "2"
+          },
+          {
+            "k": "3"
+          }
+        ]
+      },
+      "result": "6",
+      "tags": [
+        "sum filter"
+      ]
+    },
+    {
+      "name": "filters, sum, hashes with property argument",
+      "template": "{{ a | sum: 'k' }}",
+      "data": {
+        "a": [
+          {
+            "k": 1
+          },
+          {
+            "k": 2
+          },
+          {
+            "k": 3
+          }
+        ]
+      },
+      "result": "6",
+      "tags": [
+        "sum filter"
+      ]
+    },
+    {
+      "name": "filters, sum, hashes with some missing properties",
+      "template": "{{ a | sum: 'k' }}",
+      "data": {
+        "a": [
+          {
+            "k": 1
+          },
+          {
+            "k": 2
+          },
+          {
+            "x": 3
+          }
+        ]
+      },
+      "result": "3",
+      "tags": [
+        "sum filter"
+      ]
+    },
+    {
+      "name": "filters, sum, hashes without property argument",
       "template": "{{ a | sum }}",
       "data": {
         "a": [
-          0,
-          0,
-          0
+          {
+            "k": 1
+          },
+          {
+            "k": 2
+          },
+          {
+            "k": 3
+          }
         ]
       },
       "result": "0",
@@ -6474,21 +6543,6 @@
       ]
     },
     {
-      "name": "filters, sum, positive and negative ints",
-      "template": "{{ a | sum }}",
-      "data": {
-        "a": [
-          -2,
-          -3,
-          10
-        ]
-      },
-      "result": "5",
-      "tags": [
-        "sum filter"
-      ]
-    },
-    {
       "name": "filters, sum, nested ints",
       "template": "{{ a | sum }}",
       "data": {
@@ -6508,61 +6562,13 @@
       ]
     },
     {
-      "name": "filters, sum, hashes with property argument",
-      "template": "{{ a | sum: 'k' }}",
-      "data": {
-        "a": [
-          {
-            "k": 1
-          },
-          {
-            "k": 2
-          },
-          {
-            "k": 3
-          }
-        ]
-      },
-      "result": "6",
-      "tags": [
-        "sum filter"
-      ]
-    },
-    {
-      "name": "filters, sum, hashes with numeric strings and property argument",
-      "template": "{{ a | sum: 'k' }}",
-      "data": {
-        "a": [
-          {
-            "k": "1"
-          },
-          {
-            "k": "2"
-          },
-          {
-            "k": "3"
-          }
-        ]
-      },
-      "result": "6",
-      "tags": [
-        "sum filter"
-      ]
-    },
-    {
-      "name": "filters, sum, hashes without property argument",
+      "name": "filters, sum, only zeros",
       "template": "{{ a | sum }}",
       "data": {
         "a": [
-          {
-            "k": 1
-          },
-          {
-            "k": 2
-          },
-          {
-            "k": 3
-          }
+          0,
+          0,
+          0
         ]
       },
       "result": "0",
@@ -6571,22 +6577,16 @@
       ]
     },
     {
-      "name": "filters, sum, hashes with some missing properties",
-      "template": "{{ a | sum: 'k' }}",
+      "name": "filters, sum, positive and negative ints",
+      "template": "{{ a | sum }}",
       "data": {
         "a": [
-          {
-            "k": 1
-          },
-          {
-            "k": 2
-          },
-          {
-            "x": 3
-          }
+          -2,
+          -3,
+          10
         ]
       },
-      "result": "3",
+      "result": "5",
       "tags": [
         "sum filter"
       ]
@@ -6607,9 +6607,9 @@
       ]
     },
     {
-      "name": "filters, times, int times int",
-      "template": "{{ 5 | times: 2 }}",
-      "result": "10",
+      "name": "filters, times, float times float",
+      "template": "{{ 5.0 | times: 2.1 }}",
+      "result": "10.5",
       "tags": [
         "times filter"
       ]
@@ -6623,25 +6623,9 @@
       ]
     },
     {
-      "name": "filters, times, float times float",
-      "template": "{{ 5.0 | times: 2.1 }}",
-      "result": "10.5",
-      "tags": [
-        "times filter"
-      ]
-    },
-    {
-      "name": "filters, times, string times string",
-      "template": "{{ \"5.0\" | times: \"2.1\" }}",
-      "result": "10.5",
-      "tags": [
-        "times filter"
-      ]
-    },
-    {
-      "name": "filters, times, negative multiplication",
-      "template": "{{ -5 | times: 2 }}",
-      "result": "-10",
+      "name": "filters, times, int times int",
+      "template": "{{ 5 | times: 2 }}",
+      "result": "10",
       "tags": [
         "times filter"
       ]
@@ -6655,17 +6639,25 @@
       ]
     },
     {
-      "name": "filters, times, too many args",
-      "template": "{{ 5 | times: 1, 2 }}",
-      "invalid": true,
+      "name": "filters, times, negative multiplication",
+      "template": "{{ -5 | times: 2 }}",
+      "result": "-10",
       "tags": [
         "times filter"
       ]
     },
     {
-      "name": "filters, times, undefined left value",
-      "template": "{{ nosuchthing | times: 2 }}",
-      "result": "0",
+      "name": "filters, times, string times string",
+      "template": "{{ \"5.0\" | times: \"2.1\" }}",
+      "result": "10.5",
+      "tags": [
+        "times filter"
+      ]
+    },
+    {
+      "name": "filters, times, too many args",
+      "template": "{{ 5 | times: 1, 2 }}",
+      "invalid": true,
       "tags": [
         "times filter"
       ]
@@ -6679,6 +6671,22 @@
       ]
     },
     {
+      "name": "filters, times, undefined left value",
+      "template": "{{ nosuchthing | times: 2 }}",
+      "result": "0",
+      "tags": [
+        "times filter"
+      ]
+    },
+    {
+      "name": "filters, truncate, custom end",
+      "template": "{{ \"Ground control to Major Tom.\" | truncate: 25, \", and so on\" }}",
+      "result": "Ground control, and so on",
+      "tags": [
+        "truncate filter"
+      ]
+    },
+    {
       "name": "filters, truncate, default end",
       "template": "{{ \"Ground control to Major Tom.\" | truncate: 20 }}",
       "result": "Ground control to...",
@@ -6687,9 +6695,9 @@
       ]
     },
     {
-      "name": "filters, truncate, custom end",
-      "template": "{{ \"Ground control to Major Tom.\" | truncate: 25, \", and so on\" }}",
-      "result": "Ground control, and so on",
+      "name": "filters, truncate, default length is 50",
+      "template": "{{ \"Ground control to Major Tom. Ground control to Major Tom.\" | truncate }}",
+      "result": "Ground control to Major Tom. Ground control to ...",
       "tags": [
         "truncate filter"
       ]
@@ -6703,14 +6711,6 @@
       ]
     },
     {
-      "name": "filters, truncate, string is shorter than length",
-      "template": "{{ \"Ground control\" | truncate: 20 }}",
-      "result": "Ground control",
-      "tags": [
-        "truncate filter"
-      ]
-    },
-    {
       "name": "filters, truncate, not a string",
       "template": "{{ 5 | truncate: 10 }}",
       "result": "5",
@@ -6719,8 +6719,24 @@
       ]
     },
     {
+      "name": "filters, truncate, string is shorter than length",
+      "template": "{{ \"Ground control\" | truncate: 20 }}",
+      "result": "Ground control",
+      "tags": [
+        "truncate filter"
+      ]
+    },
+    {
       "name": "filters, truncate, too many arguments",
       "template": "{{ \"hello\" | truncate: 5, \"foo\", \"bar\" }}",
+      "invalid": true,
+      "tags": [
+        "truncate filter"
+      ]
+    },
+    {
+      "name": "filters, truncate, undefined first argument",
+      "template": "{{ \"Ground control to Major Tom.\" | truncate: nosuchthing }}",
       "invalid": true,
       "tags": [
         "truncate filter"
@@ -6735,14 +6751,6 @@
       ]
     },
     {
-      "name": "filters, truncate, undefined first argument",
-      "template": "{{ \"Ground control to Major Tom.\" | truncate: nosuchthing }}",
-      "invalid": true,
-      "tags": [
-        "truncate filter"
-      ]
-    },
-    {
       "name": "filters, truncate, undefined second argument",
       "template": "{{ \"Ground control to Major Tom.\" | truncate: 20, nosuchthing }}",
       "result": "Ground control to Ma",
@@ -6751,17 +6759,9 @@
       ]
     },
     {
-      "name": "filters, truncate, default length is 50",
-      "template": "{{ \"Ground control to Major Tom. Ground control to Major Tom.\" | truncate }}",
-      "result": "Ground control to Major Tom. Ground control to ...",
-      "tags": [
-        "truncate filter"
-      ]
-    },
-    {
-      "name": "filters, truncatewords, default end",
-      "template": "{{ \"Ground control to Major Tom.\" | truncatewords: 3 }}",
-      "result": "Ground control to...",
+      "name": "filters, truncatewords, all whitespace is clobbered",
+      "template": "{{ \"    one    two three    four  \" | truncatewords: 2 }}",
+      "result": "one two...",
       "tags": [
         "truncatewords filter"
       ]
@@ -6775,9 +6775,9 @@
       ]
     },
     {
-      "name": "filters, truncatewords, no end",
-      "template": "{{ \"Ground control to Major Tom.\" | truncatewords: 3, \"\" }}",
-      "result": "Ground control to",
+      "name": "filters, truncatewords, default end",
+      "template": "{{ \"Ground control to Major Tom.\" | truncatewords: 3 }}",
+      "result": "Ground control to...",
       "tags": [
         "truncatewords filter"
       ]
@@ -6791,6 +6791,14 @@
       ]
     },
     {
+      "name": "filters, truncatewords, no end",
+      "template": "{{ \"Ground control to Major Tom.\" | truncatewords: 3, \"\" }}",
+      "result": "Ground control to",
+      "tags": [
+        "truncatewords filter"
+      ]
+    },
+    {
       "name": "filters, truncatewords, not a string",
       "template": "{{ 5 | truncatewords: 10 }}",
       "result": "5",
@@ -6799,9 +6807,9 @@
       ]
     },
     {
-      "name": "filters, truncatewords, too many arguments",
-      "template": "{{ \"hello\" | truncatewords: 5, \"foo\", \"bar\" }}",
-      "invalid": true,
+      "name": "filters, truncatewords, number of words defaults to 15",
+      "template": "{{ \"a b c d e f g h i j k l m n o p q\" | truncatewords }}",
+      "result": "a b c d e f g h i j k l m n o...",
       "tags": [
         "truncatewords filter"
       ]
@@ -6847,9 +6855,9 @@
       ]
     },
     {
-      "name": "filters, truncatewords, undefined left value",
-      "template": "{{ nosuchthing | truncatewords: 5 }}",
-      "result": "",
+      "name": "filters, truncatewords, too many arguments",
+      "template": "{{ \"hello\" | truncatewords: 5, \"foo\", \"bar\" }}",
+      "invalid": true,
       "tags": [
         "truncatewords filter"
       ]
@@ -6863,120 +6871,19 @@
       ]
     },
     {
+      "name": "filters, truncatewords, undefined left value",
+      "template": "{{ nosuchthing | truncatewords: 5 }}",
+      "result": "",
+      "tags": [
+        "truncatewords filter"
+      ]
+    },
+    {
       "name": "filters, truncatewords, undefined second argument",
       "template": "{{ \"one two three four\" | truncatewords: 2, nosuchthing }}",
       "result": "one two",
       "tags": [
         "truncatewords filter"
-      ]
-    },
-    {
-      "name": "filters, truncatewords, number of words defaults to 15",
-      "template": "{{ \"a b c d e f g h i j k l m n o p q\" | truncatewords }}",
-      "result": "a b c d e f g h i j k l m n o...",
-      "tags": [
-        "truncatewords filter"
-      ]
-    },
-    {
-      "name": "filters, truncatewords, all whitespace is clobbered",
-      "template": "{{ \"    one    two three    four  \" | truncatewords: 2 }}",
-      "result": "one two...",
-      "tags": [
-        "truncatewords filter"
-      ]
-    },
-    {
-      "name": "filters, uniq, array of strings",
-      "template": "{{ a | uniq | join: '#' }}",
-      "data": {
-        "a": [
-          "a",
-          "b",
-          "b",
-          "a"
-        ]
-      },
-      "result": "a#b",
-      "tags": [
-        "join filter",
-        "uniq filter"
-      ]
-    },
-    {
-      "name": "filters, uniq, array of things",
-      "template": "{{ a | uniq | join: '#' }}",
-      "data": {
-        "a": [
-          "a",
-          "b",
-          1,
-          1
-        ]
-      },
-      "result": "a#b#1",
-      "tags": [
-        "join filter",
-        "uniq filter"
-      ]
-    },
-    {
-      "name": "filters, uniq, empty array",
-      "template": "{{ a | uniq | join: '#' }}",
-      "data": {
-        "a": []
-      },
-      "result": "",
-      "tags": [
-        "join filter",
-        "uniq filter"
-      ]
-    },
-    {
-      "name": "filters, uniq, unhashable items",
-      "template": "{{ a | uniq | join: '#' }}",
-      "data": {
-        "a": [
-          "a",
-          "b",
-          [],
-          {},
-          {}
-        ]
-      },
-      "result": "a#b#{}",
-      "tags": [
-        "join filter",
-        "uniq filter"
-      ]
-    },
-    {
-      "name": "filters, uniq, left value is not an array",
-      "template": "{{ a | uniq | join: '#' }}",
-      "data": {
-        "a": 123
-      },
-      "result": "123",
-      "tags": [
-        "join filter",
-        "uniq filter"
-      ]
-    },
-    {
-      "name": "filters, uniq, left value is undefined",
-      "template": "{{ nosuchthing | uniq | join: '#' }}",
-      "result": "",
-      "tags": [
-        "join filter",
-        "uniq filter"
-      ]
-    },
-    {
-      "name": "filters, uniq, too many arguments",
-      "template": "{{ nosuchthing | uniq: 'foo', 'bar' }}",
-      "invalid": true,
-      "tags": [
-        "uniq filter"
       ]
     },
     {
@@ -7040,6 +6947,99 @@
       ]
     },
     {
+      "name": "filters, uniq, array of strings",
+      "template": "{{ a | uniq | join: '#' }}",
+      "data": {
+        "a": [
+          "a",
+          "b",
+          "b",
+          "a"
+        ]
+      },
+      "result": "a#b",
+      "tags": [
+        "join filter",
+        "uniq filter"
+      ]
+    },
+    {
+      "name": "filters, uniq, array of things",
+      "template": "{{ a | uniq | join: '#' }}",
+      "data": {
+        "a": [
+          "a",
+          "b",
+          1,
+          1
+        ]
+      },
+      "result": "a#b#1",
+      "tags": [
+        "join filter",
+        "uniq filter"
+      ]
+    },
+    {
+      "name": "filters, uniq, empty array",
+      "template": "{{ a | uniq | join: '#' }}",
+      "data": {
+        "a": []
+      },
+      "result": "",
+      "tags": [
+        "join filter",
+        "uniq filter"
+      ]
+    },
+    {
+      "name": "filters, uniq, left value is not an array",
+      "template": "{{ a | uniq | join: '#' }}",
+      "data": {
+        "a": 123
+      },
+      "result": "123",
+      "tags": [
+        "join filter",
+        "uniq filter"
+      ]
+    },
+    {
+      "name": "filters, uniq, left value is undefined",
+      "template": "{{ nosuchthing | uniq | join: '#' }}",
+      "result": "",
+      "tags": [
+        "join filter",
+        "uniq filter"
+      ]
+    },
+    {
+      "name": "filters, uniq, too many arguments",
+      "template": "{{ nosuchthing | uniq: 'foo', 'bar' }}",
+      "invalid": true,
+      "tags": [
+        "uniq filter"
+      ]
+    },
+    {
+      "name": "filters, uniq, unhashable items",
+      "template": "{{ a | uniq | join: '#' }}",
+      "data": {
+        "a": [
+          "a",
+          "b",
+          [],
+          {},
+          {}
+        ]
+      },
+      "result": "a#b#{}",
+      "tags": [
+        "join filter",
+        "uniq filter"
+      ]
+    },
+    {
       "name": "filters, upcase, make lower case",
       "template": "{{ \"hello\" | upcase }}",
       "result": "HELLO",
@@ -7056,14 +7056,6 @@
       ]
     },
     {
-      "name": "filters, upcase, unexpected argument",
-      "template": "{{ \"hello\" | upcase: 5 }}",
-      "invalid": true,
-      "tags": [
-        "upcase filter"
-      ]
-    },
-    {
       "name": "filters, upcase, undefined left value",
       "template": "{{ nosuchthing | upcase }}",
       "result": "",
@@ -7072,11 +7064,11 @@
       ]
     },
     {
-      "name": "filters, url decode, some special URL characters",
-      "template": "{{ \"email+address+is+bob%40example.com%21\" | url_decode }}",
-      "result": "email address is bob@example.com!",
+      "name": "filters, upcase, unexpected argument",
+      "template": "{{ \"hello\" | upcase: 5 }}",
+      "invalid": true,
       "tags": [
-        "url_decode filter"
+        "upcase filter"
       ]
     },
     {
@@ -7088,9 +7080,9 @@
       ]
     },
     {
-      "name": "filters, url decode, unexpected argument",
-      "template": "{{ \"hello\" | url_decode: 5 }}",
-      "invalid": true,
+      "name": "filters, url decode, some special URL characters",
+      "template": "{{ \"email+address+is+bob%40example.com%21\" | url_decode }}",
+      "result": "email address is bob@example.com!",
       "tags": [
         "url_decode filter"
       ]
@@ -7104,11 +7096,11 @@
       ]
     },
     {
-      "name": "filters, url encode, some special URL characters",
-      "template": "{{ \"email address is bob@example.com!\" | url_encode }}",
-      "result": "email+address+is+bob%40example.com%21",
+      "name": "filters, url decode, unexpected argument",
+      "template": "{{ \"hello\" | url_decode: 5 }}",
+      "invalid": true,
       "tags": [
-        "url_encode filter"
+        "url_decode filter"
       ]
     },
     {
@@ -7120,9 +7112,9 @@
       ]
     },
     {
-      "name": "filters, url encode, unexpected argument",
-      "template": "{{ \"hello\" | url_encode: 5 }}",
-      "invalid": true,
+      "name": "filters, url encode, some special URL characters",
+      "template": "{{ \"email address is bob@example.com!\" | url_encode }}",
+      "result": "email+address+is+bob%40example.com%21",
       "tags": [
         "url_encode filter"
       ]
@@ -7131,6 +7123,14 @@
       "name": "filters, url encode, undefined left value",
       "template": "{{ nosuchthing | url_encode }}",
       "result": "",
+      "tags": [
+        "url_encode filter"
+      ]
+    },
+    {
+      "name": "filters, url encode, unexpected argument",
+      "template": "{{ \"hello\" | url_encode: 5 }}",
+      "invalid": true,
       "tags": [
         "url_encode filter"
       ]
@@ -7152,29 +7152,6 @@
         ]
       },
       "result": "(title,foo)(title,bar)",
-      "tags": [
-        "assign tag",
-        "for tag",
-        "where filter"
-      ]
-    },
-    {
-      "name": "filters, where, array of hashes with equality test",
-      "template": "{% assign x = a | where: 'title', 'bar' %}{% for obj in x %}{% for i in obj %}({{ i[0] }},{{ i[1] }}){% endfor %}{% endfor %}",
-      "data": {
-        "a": [
-          {
-            "title": "foo"
-          },
-          {
-            "title": "bar"
-          },
-          {
-            "title": null
-          }
-        ]
-      },
-      "result": "(title,bar)",
       "tags": [
         "assign tag",
         "for tag",
@@ -7205,19 +7182,8 @@
       ]
     },
     {
-      "name": "filters, where, left value is not an array",
-      "template": "{{ a | where: 'title' }}",
-      "data": {
-        "a": 123
-      },
-      "invalid": true,
-      "tags": [
-        "where filter"
-      ]
-    },
-    {
-      "name": "filters, where, missing argument",
-      "template": "{{ a | where }}",
+      "name": "filters, where, array of hashes with equality test",
+      "template": "{% assign x = a | where: 'title', 'bar' %}{% for obj in x %}{% for i in obj %}({{ i[0] }},{{ i[1] }}){% endfor %}{% endfor %}",
       "data": {
         "a": [
           {
@@ -7231,78 +7197,7 @@
           }
         ]
       },
-      "invalid": true,
-      "tags": [
-        "where filter"
-      ]
-    },
-    {
-      "name": "filters, where, too many arguments",
-      "template": "{{ a | where: 'title', 'foo', 'bar' }}",
-      "data": {
-        "a": [
-          {
-            "title": "foo"
-          },
-          {
-            "title": "bar"
-          },
-          {
-            "title": null
-          }
-        ]
-      },
-      "invalid": true,
-      "tags": [
-        "where filter"
-      ]
-    },
-    {
-      "name": "filters, where, left value is undefined",
-      "template": "{{ nosuchthing | where: 'title' }}",
-      "result": "",
-      "tags": [
-        "where filter"
-      ]
-    },
-    {
-      "name": "filters, where, first argument is undefined",
-      "template": "{{ a | where: nosuchthing }}",
-      "data": {
-        "a": [
-          {
-            "title": "foo"
-          },
-          {
-            "title": "bar"
-          },
-          {
-            "title": null
-          }
-        ]
-      },
-      "result": "",
-      "tags": [
-        "where filter"
-      ]
-    },
-    {
-      "name": "filters, where, second argument is undefined",
-      "template": "{% assign x = a | where: 'title', nosuchthing %}{% for obj in x %}{% for i in obj %}({{ i[0] }},{{ i[1] }}){% endfor %}{% endfor %}",
-      "data": {
-        "a": [
-          {
-            "title": "foo"
-          },
-          {
-            "title": "bar"
-          },
-          {
-            "title": null
-          }
-        ]
-      },
-      "result": "(title,foo)(title,bar)",
+      "result": "(title,bar)",
       "tags": [
         "assign tag",
         "for tag",
@@ -7331,25 +7226,107 @@
       ]
     },
     {
-      "name": "filters, where, value is false",
-      "template": "{% assign x =  a | where: 'b', false %}{% for obj in x %}{% for i in obj %}({{ i[0] }},{{ i[1] }}){% endfor %}{% endfor %}",
+      "name": "filters, where, first argument is undefined",
+      "template": "{{ a | where: nosuchthing }}",
       "data": {
         "a": [
           {
-            "b": false
+            "title": "foo"
           },
           {
-            "b": "bar"
+            "title": "bar"
           },
           {
-            "b": null
+            "title": null
           }
         ]
       },
-      "result": "(b,false)",
+      "result": "",
+      "tags": [
+        "where filter"
+      ]
+    },
+    {
+      "name": "filters, where, left value is not an array",
+      "template": "{{ a | where: 'title' }}",
+      "data": {
+        "a": 123
+      },
+      "invalid": true,
+      "tags": [
+        "where filter"
+      ]
+    },
+    {
+      "name": "filters, where, left value is undefined",
+      "template": "{{ nosuchthing | where: 'title' }}",
+      "result": "",
+      "tags": [
+        "where filter"
+      ]
+    },
+    {
+      "name": "filters, where, missing argument",
+      "template": "{{ a | where }}",
+      "data": {
+        "a": [
+          {
+            "title": "foo"
+          },
+          {
+            "title": "bar"
+          },
+          {
+            "title": null
+          }
+        ]
+      },
+      "invalid": true,
+      "tags": [
+        "where filter"
+      ]
+    },
+    {
+      "name": "filters, where, second argument is undefined",
+      "template": "{% assign x = a | where: 'title', nosuchthing %}{% for obj in x %}{% for i in obj %}({{ i[0] }},{{ i[1] }}){% endfor %}{% endfor %}",
+      "data": {
+        "a": [
+          {
+            "title": "foo"
+          },
+          {
+            "title": "bar"
+          },
+          {
+            "title": null
+          }
+        ]
+      },
+      "result": "(title,foo)(title,bar)",
       "tags": [
         "assign tag",
         "for tag",
+        "where filter"
+      ]
+    },
+    {
+      "name": "filters, where, too many arguments",
+      "template": "{{ a | where: 'title', 'foo', 'bar' }}",
+      "data": {
+        "a": [
+          {
+            "title": "foo"
+          },
+          {
+            "title": "bar"
+          },
+          {
+            "title": null
+          }
+        ]
+      },
+      "invalid": true,
+      "tags": [
         "where filter"
       ]
     },
@@ -7377,21 +7354,32 @@
       ]
     },
     {
-      "name": "tags, assign, assign a filtered literal",
-      "template": "{% assign foo = 'foo' | upcase %}{{ foo }}",
-      "result": "FOO",
+      "name": "filters, where, value is false",
+      "template": "{% assign x =  a | where: 'b', false %}{% for obj in x %}{% for i in obj %}({{ i[0] }},{{ i[1] }}){% endfor %}{% endfor %}",
+      "data": {
+        "a": [
+          {
+            "b": false
+          },
+          {
+            "b": "bar"
+          },
+          {
+            "b": null
+          }
+        ]
+      },
+      "result": "(b,false)",
       "tags": [
         "assign tag",
-        "upcase filter"
+        "for tag",
+        "where filter"
       ]
     },
     {
-      "name": "tags, assign, local variables shadow global variables",
-      "template": "{{ foo }}{% assign foo = 'foo' | upcase %}{{ foo }}",
-      "data": {
-        "foo": "bar"
-      },
-      "result": "barFOO",
+      "name": "tags, assign, assign a filtered literal",
+      "template": "{% assign foo = 'foo' | upcase %}{{ foo }}",
+      "result": "FOO",
       "tags": [
         "assign tag",
         "upcase filter"
@@ -7404,14 +7392,6 @@
       "tags": [
         "assign tag",
         "join filter"
-      ]
-    },
-    {
-      "name": "tags, assign, assign to variable with a hyphen",
-      "template": "{% assign some-thing = 'foo' %}{{ some-thing }}",
-      "result": "foo",
-      "tags": [
-        "assign tag"
       ]
     },
     {
@@ -7443,6 +7423,14 @@
       ]
     },
     {
+      "name": "tags, assign, assign to variable with a hyphen",
+      "template": "{% assign some-thing = 'foo' %}{{ some-thing }}",
+      "result": "foo",
+      "tags": [
+        "assign tag"
+      ]
+    },
+    {
       "name": "tags, assign, assign with quoted notation and extra whitespace",
       "template": "{% assign foo = bar[ 'baz'  ] %}{{ foo }}",
       "data": {
@@ -7456,15 +7444,23 @@
       ]
     },
     {
-      "name": "tags, capture, capture template literal and global variable",
-      "template": "{% capture greeting %}Hello, {{ customer.first_name }}.{% endcapture %}{{ greeting }}",
+      "name": "tags, assign, local variables shadow global variables",
+      "template": "{{ foo }}{% assign foo = 'foo' | upcase %}{{ foo }}",
       "data": {
-        "customer": {
-          "first_name": "Holly"
-        }
+        "foo": "bar"
       },
-      "result": "Hello, Holly.",
+      "result": "barFOO",
       "tags": [
+        "assign tag",
+        "upcase filter"
+      ]
+    },
+    {
+      "name": "tags, capture, assign to a variable from a captured variable",
+      "template": "{% capture some %}hello{% endcapture %}{% assign other = some %}{{ some }}-{{ other }}",
+      "result": "hello-hello",
+      "tags": [
+        "assign tag",
         "capture tag"
       ]
     },
@@ -7482,23 +7478,16 @@
       ]
     },
     {
-      "name": "tags, capture, assign to a variable from a captured variable",
-      "template": "{% capture some %}hello{% endcapture %}{% assign other = some %}{{ some }}-{{ other }}",
-      "result": "hello-hello",
-      "tags": [
-        "assign tag",
-        "capture tag"
-      ]
-    },
-    {
-      "name": "tags, case, simple case/when",
-      "template": "{% case title %}{% when 'foo' %}foo{% when 'Hello' %}bar{% endcase %}",
+      "name": "tags, capture, capture template literal and global variable",
+      "template": "{% capture greeting %}Hello, {{ customer.first_name }}.{% endcapture %}{{ greeting }}",
       "data": {
-        "title": "Hello"
+        "customer": {
+          "first_name": "Holly"
+        }
       },
-      "result": "bar",
+      "result": "Hello, Holly.",
       "tags": [
-        "case tag"
+        "capture tag"
       ]
     },
     {
@@ -7514,84 +7503,8 @@
       ]
     },
     {
-      "name": "tags, case, tags inside when block",
-      "template": "{% case title %}{% when other %}{% if true %}foo{% endif %}{% when 'goodbye' %}bar{% endcase %}",
-      "data": {
-        "title": "Hello",
-        "other": "Hello"
-      },
-      "result": "foo",
-      "tags": [
-        "case tag",
-        "if tag"
-      ]
-    },
-    {
       "name": "tags, case, 'when' expression using an out of scope identifier",
       "template": "{% case title %}{% when nosuchthing %}foo{% when 'Hello' %}bar{% endcase %}",
-      "data": {
-        "title": "Hello"
-      },
-      "result": "bar",
-      "tags": [
-        "case tag"
-      ]
-    },
-    {
-      "name": "tags, case, name not in scope",
-      "template": "{% case nosuchthing %}{% when 'foo' %}foo{% when 'bar' %}bar{% endcase %}",
-      "result": "",
-      "tags": [
-        "case tag"
-      ]
-    },
-    {
-      "name": "tags, case, no match and no default",
-      "template": "{% case title %}{% when 'foo' %}foo{% when 'bar' %}bar{% endcase %}",
-      "data": {
-        "title": "Hello"
-      },
-      "result": "",
-      "tags": [
-        "case tag"
-      ]
-    },
-    {
-      "name": "tags, case, with default",
-      "template": "{% case title %}{% when 'foo' %}foo{% else %}bar{% endcase %}",
-      "data": {
-        "title": "Hello"
-      },
-      "result": "bar",
-      "tags": [
-        "case tag"
-      ]
-    },
-    {
-      "name": "tags, case, no whens",
-      "template": "{% case title %}{% else %}bar{% endcase %}",
-      "data": {
-        "title": "Hello"
-      },
-      "result": "bar",
-      "tags": [
-        "case tag"
-      ]
-    },
-    {
-      "name": "tags, case, no whens or default",
-      "template": "{% case title %}{% endcase %}",
-      "data": {
-        "title": "Hello"
-      },
-      "result": "",
-      "tags": [
-        "case tag"
-      ]
-    },
-    {
-      "name": "tags, case, whitespace",
-      "template": "{% case title %}  \n\t{% when 'foo' %}foo\n{% when 'Hello' %}bar{% endcase %}",
       "data": {
         "title": "Hello"
       },
@@ -7607,51 +7520,6 @@
         "title": "Hello"
       },
       "result": "bar",
-      "tags": [
-        "case tag"
-      ]
-    },
-    {
-      "name": "tags, case, evaluate multiple matching blocks",
-      "template": "{% case title %}{% when 'Hello' %}foo{% when a, 'Hello' %}bar{% endcase %}",
-      "data": {
-        "title": "Hello",
-        "a": "Hello"
-      },
-      "result": "foobarbar",
-      "tags": [
-        "case tag"
-      ]
-    },
-    {
-      "name": "tags, case, or separated when expression",
-      "template": "{% case title %}{% when 'foo' %}foo{% when 'bar' or 'Hello' %}bar{% endcase %}",
-      "data": {
-        "title": "Hello"
-      },
-      "result": "bar",
-      "tags": [
-        "case tag"
-      ]
-    },
-    {
-      "name": "tags, case, mix or and comma separated when expression",
-      "template": "{% case title %}{% when 'foo' %}foo{% when 'bar' or 'Hello', 'Hello' %}bar{% endcase %}",
-      "data": {
-        "title": "Hello"
-      },
-      "result": "barbar",
-      "tags": [
-        "case tag"
-      ]
-    },
-    {
-      "name": "tags, case, unexpected when token",
-      "template": "{% case title %}{% when 'foo' %}foo{% when 'bar' and 'Hello', 'Hello' %}bar{% endcase %}",
-      "data": {
-        "title": "Hello"
-      },
-      "result": "",
       "tags": [
         "case tag"
       ]
@@ -7679,29 +7547,13 @@
       ]
     },
     {
-      "name": "tags, case, switch on array",
-      "template": "{% case x %}{% when y %}foo{% endcase %}",
+      "name": "tags, case, evaluate multiple matching blocks",
+      "template": "{% case title %}{% when 'Hello' %}foo{% when a, 'Hello' %}bar{% endcase %}",
       "data": {
-        "x": [
-          "a",
-          "b",
-          "c"
-        ],
-        "y": [
-          "a",
-          "b",
-          "c"
-        ]
+        "title": "Hello",
+        "a": "Hello"
       },
-      "result": "foo",
-      "tags": [
-        "case tag"
-      ]
-    },
-    {
-      "name": "tags, case, multiple else blocks",
-      "template": "{% case 'x' %}{% when 'y' %}foo{% else %}bar{% else %}baz{% endcase %}",
-      "result": "barbaz",
+      "result": "foobarbar",
       "tags": [
         "case tag"
       ]
@@ -7723,11 +7575,118 @@
       ]
     },
     {
-      "name": "tags, case, truthy when before and after else",
-      "template": "{% case 'x' %}{% when 'x' %}foo{% else %}bar{% when 'x' %}baz{% endcase %}",
-      "result": "foobaz",
+      "name": "tags, case, mix or and comma separated when expression",
+      "template": "{% case title %}{% when 'foo' %}foo{% when 'bar' or 'Hello', 'Hello' %}bar{% endcase %}",
+      "data": {
+        "title": "Hello"
+      },
+      "result": "barbar",
       "tags": [
         "case tag"
+      ]
+    },
+    {
+      "name": "tags, case, multiple else blocks",
+      "template": "{% case 'x' %}{% when 'y' %}foo{% else %}bar{% else %}baz{% endcase %}",
+      "result": "barbaz",
+      "tags": [
+        "case tag"
+      ]
+    },
+    {
+      "name": "tags, case, name not in scope",
+      "template": "{% case nosuchthing %}{% when 'foo' %}foo{% when 'bar' %}bar{% endcase %}",
+      "result": "",
+      "tags": [
+        "case tag"
+      ]
+    },
+    {
+      "name": "tags, case, no match and no default",
+      "template": "{% case title %}{% when 'foo' %}foo{% when 'bar' %}bar{% endcase %}",
+      "data": {
+        "title": "Hello"
+      },
+      "result": "",
+      "tags": [
+        "case tag"
+      ]
+    },
+    {
+      "name": "tags, case, no whens",
+      "template": "{% case title %}{% else %}bar{% endcase %}",
+      "data": {
+        "title": "Hello"
+      },
+      "result": "bar",
+      "tags": [
+        "case tag"
+      ]
+    },
+    {
+      "name": "tags, case, no whens or default",
+      "template": "{% case title %}{% endcase %}",
+      "data": {
+        "title": "Hello"
+      },
+      "result": "",
+      "tags": [
+        "case tag"
+      ]
+    },
+    {
+      "name": "tags, case, or separated when expression",
+      "template": "{% case title %}{% when 'foo' %}foo{% when 'bar' or 'Hello' %}bar{% endcase %}",
+      "data": {
+        "title": "Hello"
+      },
+      "result": "bar",
+      "tags": [
+        "case tag"
+      ]
+    },
+    {
+      "name": "tags, case, simple case/when",
+      "template": "{% case title %}{% when 'foo' %}foo{% when 'Hello' %}bar{% endcase %}",
+      "data": {
+        "title": "Hello"
+      },
+      "result": "bar",
+      "tags": [
+        "case tag"
+      ]
+    },
+    {
+      "name": "tags, case, switch on array",
+      "template": "{% case x %}{% when y %}foo{% endcase %}",
+      "data": {
+        "x": [
+          "a",
+          "b",
+          "c"
+        ],
+        "y": [
+          "a",
+          "b",
+          "c"
+        ]
+      },
+      "result": "foo",
+      "tags": [
+        "case tag"
+      ]
+    },
+    {
+      "name": "tags, case, tags inside when block",
+      "template": "{% case title %}{% when other %}{% if true %}foo{% endif %}{% when 'goodbye' %}bar{% endcase %}",
+      "data": {
+        "title": "Hello",
+        "other": "Hello"
+      },
+      "result": "foo",
+      "tags": [
+        "case tag",
+        "if tag"
       ]
     },
     {
@@ -7739,27 +7698,44 @@
       ]
     },
     {
-      "name": "tags, comment, don't render comments",
-      "template": "{% comment %}foo{% endcomment %}",
-      "result": "",
+      "name": "tags, case, truthy when before and after else",
+      "template": "{% case 'x' %}{% when 'x' %}foo{% else %}bar{% when 'x' %}baz{% endcase %}",
+      "result": "foobaz",
       "tags": [
-        "comment tag"
+        "case tag"
       ]
     },
     {
-      "name": "tags, comment, respect whitespace control in comments",
-      "template": "\n{%- comment %}foo{% endcomment -%}\t \r",
+      "name": "tags, case, unexpected when token",
+      "template": "{% case title %}{% when 'foo' %}foo{% when 'bar' and 'Hello', 'Hello' %}bar{% endcase %}",
+      "data": {
+        "title": "Hello"
+      },
       "result": "",
       "tags": [
-        "comment tag"
+        "case tag"
       ]
     },
     {
-      "name": "tags, comment, don't render comments with tags",
-      "template": "{% comment %}{% if true %}{{ title }}{% endif %}{% endcomment %}",
-      "result": "",
+      "name": "tags, case, whitespace",
+      "template": "{% case title %}  \n\t{% when 'foo' %}foo\n{% when 'Hello' %}bar{% endcase %}",
+      "data": {
+        "title": "Hello"
+      },
+      "result": "bar",
       "tags": [
-        "comment tag"
+        "case tag"
+      ]
+    },
+    {
+      "name": "tags, case, with default",
+      "template": "{% case title %}{% when 'foo' %}foo{% else %}bar{% endcase %}",
+      "data": {
+        "title": "Hello"
+      },
+      "result": "bar",
+      "tags": [
+        "case tag"
       ]
     },
     {
@@ -7781,9 +7757,17 @@
       ]
     },
     {
-      "name": "tags, comment, malformed tags are not parsed",
-      "template": "{% comment %}{% assign foo = '1'{% endcomment %}",
-      "invalid": true,
+      "name": "tags, comment, don't render comments",
+      "template": "{% comment %}foo{% endcomment %}",
+      "result": "",
+      "tags": [
+        "comment tag"
+      ]
+    },
+    {
+      "name": "tags, comment, don't render comments with tags",
+      "template": "{% comment %}{% if true %}{{ title }}{% endif %}{% endcomment %}",
+      "result": "",
       "tags": [
         "comment tag"
       ]
@@ -7791,6 +7775,14 @@
     {
       "name": "tags, comment, incomplete tags are not parsed",
       "template": "{% comment %}{% {{ {%- endcomment %}",
+      "invalid": true,
+      "tags": [
+        "comment tag"
+      ]
+    },
+    {
+      "name": "tags, comment, malformed tags are not parsed",
+      "template": "{% comment %}{% assign foo = '1'{% endcomment %}",
       "invalid": true,
       "tags": [
         "comment tag"
@@ -7813,14 +7805,6 @@
       ]
     },
     {
-      "name": "tags, comment, unclosed nested comment blocks",
-      "template": "{% comment %}    {% comment %}    {% comment %}    {% endcomment %}{% endcomment %}",
-      "invalid": true,
-      "tags": [
-        "comment tag"
-      ]
-    },
-    {
       "name": "tags, comment, raw inside comment block",
       "template": "{% comment %}    {% raw %}    {% endcomment %}    {% endraw %}{% endcomment %}",
       "result": "",
@@ -7829,18 +7813,30 @@
       ]
     },
     {
-      "name": "tags, cycle, no identifier",
-      "template": "{% cycle 'some', 'other' %}{% cycle 'some', 'other' %}{% cycle 'some', 'other' %}",
-      "result": "someothersome",
+      "name": "tags, comment, respect whitespace control in comments",
+      "template": "\n{%- comment %}foo{% endcomment -%}\t \r",
+      "result": "",
       "tags": [
-        "cycle tag"
+        "comment tag"
       ]
     },
     {
-      "name": "tags, cycle, with identifier",
-      "template": "{% cycle 'foo': 'some', 'other' %}{% cycle 'some', 'other' %}{% cycle 'foo': 'some', 'other' %}",
-      "result": "somesomeother",
+      "name": "tags, comment, unclosed nested comment blocks",
+      "template": "{% comment %}    {% comment %}    {% comment %}    {% endcomment %}{% endcomment %}",
+      "invalid": true,
       "tags": [
+        "comment tag"
+      ]
+    },
+    {
+      "name": "tags, cycle, changing variable name",
+      "template": "{% cycle a: 1, 2, 3 %}{% assign a = 'bar' %}{% cycle a: 1, 2, 3 %}{% cycle a: 1, 2, 3 %}",
+      "data": {
+        "a": "foo"
+      },
+      "result": "112",
+      "tags": [
+        "assign tag",
         "cycle tag"
       ]
     },
@@ -7861,41 +7857,10 @@
       ]
     },
     {
-      "name": "tags, cycle, variable name",
-      "template": "{% cycle a: 1, 2, 3 %}{% cycle a: 1, 2, 3 %}{% cycle a: 1, 2, 3 %}",
-      "data": {
-        "a": "foo"
-      },
-      "result": "123",
-      "tags": [
-        "cycle tag"
-      ]
-    },
-    {
       "name": "tags, cycle, multiple undefined variable names",
       "template": "{% cycle a: 1, 2, 3 %}{% cycle b: 1, 2, 3 %}{% cycle a: 1, 2, 3 %}",
       "result": "123",
       "tags": [
-        "cycle tag"
-      ]
-    },
-    {
-      "name": "tags, cycle, undefined variable names mixed with no name",
-      "template": "{% cycle a: 1, 2, 3 %}{% cycle b: 1, 2, 3 %}{% cycle 1, 2, 3 %}",
-      "result": "121",
-      "tags": [
-        "cycle tag"
-      ]
-    },
-    {
-      "name": "tags, cycle, changing variable name",
-      "template": "{% cycle a: 1, 2, 3 %}{% assign a = 'bar' %}{% cycle a: 1, 2, 3 %}{% cycle a: 1, 2, 3 %}",
-      "data": {
-        "a": "foo"
-      },
-      "result": "112",
-      "tags": [
-        "assign tag",
         "cycle tag"
       ]
     },
@@ -7916,14 +7881,6 @@
       ]
     },
     {
-      "name": "tags, cycle, named with shrinking number of arguments",
-      "template": "{% cycle a: '1', '2', '3' %}{% cycle a: '1', '2' %}{% cycle a: '1' %}",
-      "result": "121",
-      "tags": [
-        "cycle tag"
-      ]
-    },
-    {
       "name": "tags, cycle, named with growing number of arguments",
       "template": "{% cycle a: '1' %}{% cycle a: '1', '2' %}{% cycle a: '1', '2', '3' %}",
       "result": "112",
@@ -7932,11 +7889,46 @@
       ]
     },
     {
-      "name": "tags, decrement, named counter",
-      "template": "{% decrement foo %}{{ foo }} {% decrement foo %}{{ foo }}",
-      "result": "-1-1 -2-2",
+      "name": "tags, cycle, named with shrinking number of arguments",
+      "template": "{% cycle a: '1', '2', '3' %}{% cycle a: '1', '2' %}{% cycle a: '1' %}",
+      "result": "121",
       "tags": [
-        "decrement tag"
+        "cycle tag"
+      ]
+    },
+    {
+      "name": "tags, cycle, no identifier",
+      "template": "{% cycle 'some', 'other' %}{% cycle 'some', 'other' %}{% cycle 'some', 'other' %}",
+      "result": "someothersome",
+      "tags": [
+        "cycle tag"
+      ]
+    },
+    {
+      "name": "tags, cycle, undefined variable names mixed with no name",
+      "template": "{% cycle a: 1, 2, 3 %}{% cycle b: 1, 2, 3 %}{% cycle 1, 2, 3 %}",
+      "result": "121",
+      "tags": [
+        "cycle tag"
+      ]
+    },
+    {
+      "name": "tags, cycle, variable name",
+      "template": "{% cycle a: 1, 2, 3 %}{% cycle a: 1, 2, 3 %}{% cycle a: 1, 2, 3 %}",
+      "data": {
+        "a": "foo"
+      },
+      "result": "123",
+      "tags": [
+        "cycle tag"
+      ]
+    },
+    {
+      "name": "tags, cycle, with identifier",
+      "template": "{% cycle 'foo': 'some', 'other' %}{% cycle 'some', 'other' %}{% cycle 'foo': 'some', 'other' %}",
+      "result": "somesomeother",
+      "tags": [
+        "cycle tag"
       ]
     },
     {
@@ -7949,11 +7941,11 @@
       ]
     },
     {
-      "name": "tags, doc, don't render docs",
-      "template": "{% doc %}don't render me{% enddoc %}",
-      "result": "",
+      "name": "tags, decrement, named counter",
+      "template": "{% decrement foo %}{{ foo }} {% decrement foo %}{{ foo }}",
+      "result": "-1-1 -2-2",
       "tags": [
-        "doc tag"
+        "decrement tag"
       ]
     },
     {
@@ -7981,9 +7973,9 @@
       ]
     },
     {
-      "name": "tags, doc, nested docs are not allowed",
-      "template": "{% doc hello %}Hello{% doc %}{% enddoc %}",
-      "invalid": true,
+      "name": "tags, doc, docs containing unclosed output are ok",
+      "template": "{% doc %}{{ foo {% enddoc %}",
+      "result": "",
       "tags": [
         "doc tag"
       ]
@@ -7997,9 +7989,17 @@
       ]
     },
     {
-      "name": "tags, doc, docs containing unclosed output are ok",
-      "template": "{% doc %}{{ foo {% enddoc %}",
+      "name": "tags, doc, don't render docs",
+      "template": "{% doc %}don't render me{% enddoc %}",
       "result": "",
+      "tags": [
+        "doc tag"
+      ]
+    },
+    {
+      "name": "tags, doc, nested docs are not allowed",
+      "template": "{% doc hello %}Hello{% doc %}{% enddoc %}",
+      "invalid": true,
       "tags": [
         "doc tag"
       ]
@@ -8010,73 +8010,6 @@
       "result": "foobar",
       "tags": [
         "doc tag"
-      ]
-    },
-    {
-      "name": "tags, echo, render a string literal",
-      "template": "{% echo 'hello' %}",
-      "result": "hello",
-      "tags": [
-        "echo tag"
-      ]
-    },
-    {
-      "name": "tags, echo, render an integer literal",
-      "template": "{% echo 123 %}",
-      "result": "123",
-      "tags": [
-        "echo tag"
-      ]
-    },
-    {
-      "name": "tags, echo, render a float literal",
-      "template": "{% echo 1.23 %}",
-      "result": "1.23",
-      "tags": [
-        "echo tag"
-      ]
-    },
-    {
-      "name": "tags, echo, render a variable from the global namespace",
-      "template": "{% echo product.title %}",
-      "data": {
-        "product": {
-          "title": "foo"
-        }
-      },
-      "result": "foo",
-      "tags": [
-        "echo tag"
-      ]
-    },
-    {
-      "name": "tags, echo, render a variable from the local namespace",
-      "template": "{% assign name = 'Brian' %}{% echo name %}",
-      "result": "Brian",
-      "tags": [
-        "assign tag",
-        "echo tag"
-      ]
-    },
-    {
-      "name": "tags, echo, render an undefined variable",
-      "template": "{% echo age %}",
-      "result": "",
-      "tags": [
-        "echo tag"
-      ]
-    },
-    {
-      "name": "tags, echo, render an undefined property",
-      "template": "{% echo product.age %}",
-      "data": {
-        "product": {
-          "title": "foo"
-        }
-      },
-      "result": "",
-      "tags": [
-        "echo tag"
       ]
     },
     {
@@ -8112,6 +8045,14 @@
       ]
     },
     {
+      "name": "tags, echo, access an undefined variable by index",
+      "template": "{% echo nosuchthing[0] %}",
+      "result": "",
+      "tags": [
+        "echo tag"
+      ]
+    },
+    {
       "name": "tags, echo, access array item by index stored in a local variable",
       "template": "{% assign i = 1 %}{% echo product.tags[i] %}",
       "data": {
@@ -8129,17 +8070,13 @@
       ]
     },
     {
-      "name": "tags, echo, render a global identifier with a filter",
-      "template": "{% echo product.title | upcase %}",
-      "data": {
-        "product": {
-          "title": "foo"
-        }
-      },
-      "result": "FOO",
+      "name": "tags, echo, assign a variable the value of an existing variable",
+      "template": "{% capture some %}hello{% endcapture %}{% assign other = some %}{% assign some = 'foo' %}{% echo some %}-{% echo other %}",
+      "result": "foo-hello",
       "tags": [
-        "echo tag",
-        "upcase filter"
+        "assign tag",
+        "capture tag",
+        "echo tag"
       ]
     },
     {
@@ -8159,12 +8096,91 @@
       ]
     },
     {
-      "name": "tags, echo, assign a variable the value of an existing variable",
-      "template": "{% capture some %}hello{% endcapture %}{% assign other = some %}{% assign some = 'foo' %}{% echo some %}-{% echo other %}",
-      "result": "foo-hello",
+      "name": "tags, echo, nothing to echo",
+      "template": "{% echo %}",
+      "result": "",
+      "tags": [
+        "echo tag"
+      ]
+    },
+    {
+      "name": "tags, echo, render a float literal",
+      "template": "{% echo 1.23 %}",
+      "result": "1.23",
+      "tags": [
+        "echo tag"
+      ]
+    },
+    {
+      "name": "tags, echo, render a global identifier with a filter",
+      "template": "{% echo product.title | upcase %}",
+      "data": {
+        "product": {
+          "title": "foo"
+        }
+      },
+      "result": "FOO",
+      "tags": [
+        "echo tag",
+        "upcase filter"
+      ]
+    },
+    {
+      "name": "tags, echo, render a string literal",
+      "template": "{% echo 'hello' %}",
+      "result": "hello",
+      "tags": [
+        "echo tag"
+      ]
+    },
+    {
+      "name": "tags, echo, render a variable from the global namespace",
+      "template": "{% echo product.title %}",
+      "data": {
+        "product": {
+          "title": "foo"
+        }
+      },
+      "result": "foo",
+      "tags": [
+        "echo tag"
+      ]
+    },
+    {
+      "name": "tags, echo, render a variable from the local namespace",
+      "template": "{% assign name = 'Brian' %}{% echo name %}",
+      "result": "Brian",
       "tags": [
         "assign tag",
-        "capture tag",
+        "echo tag"
+      ]
+    },
+    {
+      "name": "tags, echo, render an integer literal",
+      "template": "{% echo 123 %}",
+      "result": "123",
+      "tags": [
+        "echo tag"
+      ]
+    },
+    {
+      "name": "tags, echo, render an undefined property",
+      "template": "{% echo product.age %}",
+      "data": {
+        "product": {
+          "title": "foo"
+        }
+      },
+      "result": "",
+      "tags": [
+        "echo tag"
+      ]
+    },
+    {
+      "name": "tags, echo, render an undefined variable",
+      "template": "{% echo age %}",
+      "result": "",
+      "tags": [
         "echo tag"
       ]
     },
@@ -8192,49 +8208,16 @@
       ]
     },
     {
-      "name": "tags, echo, access an undefined variable by index",
-      "template": "{% echo nosuchthing[0] %}",
-      "result": "",
-      "tags": [
-        "echo tag"
-      ]
-    },
-    {
-      "name": "tags, echo, nothing to echo",
-      "template": "{% echo %}",
-      "result": "",
-      "tags": [
-        "echo tag"
-      ]
-    },
-    {
-      "name": "tags, for, simple range loop",
-      "template": "{% for i in (0..3) %}{{ i }} {% endfor %}",
-      "result": "0 1 2 3 ",
+      "name": "tags, for, access parentloop",
+      "template": "{% for i in (1..2)%}{% for j in (1..2) %}{{ i }} {{j}} {{ forloop.parentloop.index }} {{ forloop.index }} {% endfor %}{% endfor %}",
+      "result": "1 1 1 1 1 2 1 2 2 1 2 1 2 2 2 2 ",
       "tags": [
         "for tag"
       ]
     },
     {
-      "name": "tags, for, range loop using identifier",
-      "template": "{% for i in (0..product.end_range) %}{{ i }} - {{ product.tags[i] }} {% endfor %}",
-      "data": {
-        "product": {
-          "tags": [
-            "sports",
-            "garden"
-          ],
-          "end_range": 1
-        }
-      },
-      "result": "0 - sports 1 - garden ",
-      "tags": [
-        "for tag"
-      ]
-    },
-    {
-      "name": "tags, for, simple array loop",
-      "template": "{% for tag in product.tags %}{{ tag }} {% endfor %}",
+      "name": "tags, for, assign inside loop",
+      "template": "{% for tag in product.tags %}{% assign x = tag %}{% endfor %}{{ x }}",
       "data": {
         "product": {
           "tags": [
@@ -8243,52 +8226,16 @@
           ]
         }
       },
-      "result": "sports garden ",
+      "result": "garden",
       "tags": [
+        "assign tag",
         "for tag"
       ]
     },
     {
-      "name": "tags, for, loop over an array in reverse",
-      "template": "{% for tag in product.tags reversed %}{{ tag }} {% endfor %}",
-      "data": {
-        "product": {
-          "tags": [
-            "sports",
-            "garden"
-          ]
-        }
-      },
-      "result": "garden sports ",
-      "tags": [
-        "for tag"
-      ]
-    },
-    {
-      "name": "tags, for, simple hash loop",
-      "template": "{% for c in collection %}{{ c[0] }} {{ c[1] }} {% endfor %}",
-      "data": {
-        "collection": {
-          "title": "foo",
-          "description": "bar"
-        }
-      },
-      "result": "title foo description bar ",
-      "tags": [
-        "for tag"
-      ]
-    },
-    {
-      "name": "tags, for, empty array with default",
-      "template": "{% for img in emptythings.array %}{{ img.url }} {% else %}no images{% endfor %}",
-      "data": {
-        "emptythings": {
-          "array": [],
-          "map": {},
-          "string": ""
-        }
-      },
-      "result": "no images",
+      "name": "tags, for, blank empty loops",
+      "template": "{% for i in (0..10) %}  {% endfor %}",
+      "result": "",
       "tags": [
         "for tag"
       ]
@@ -8312,6 +8259,14 @@
       ]
     },
     {
+      "name": "tags, for, comma separated arguments",
+      "template": "{% for i in (1..6), limit: 4, offset: 2 %}{{ i }} {% endfor %}",
+      "result": "3 4 5 6 ",
+      "tags": [
+        "for tag"
+      ]
+    },
+    {
       "name": "tags, for, continue",
       "template": "{% for tag in product.tags %}{% if tag == 'sports' %}{% continue %}{% else %}{{ tag }} {% endif %}{% else %}no images{% endfor %}",
       "data": {
@@ -8330,24 +8285,152 @@
       ]
     },
     {
-      "name": "tags, for, limit",
-      "template": "{% for tag in product.tags limit:1 %}{{ tag }} {% endfor %}",
+      "name": "tags, for, continue a loop",
+      "template": "{% for item in array limit: 3 %}a{{ item }} {% endfor %}{% for item in array offset: continue %}b{{ item }} {% endfor %}",
       "data": {
-        "product": {
-          "tags": [
-            "sports",
-            "garden"
-          ]
-        }
+        "array": [
+          1,
+          2,
+          3,
+          4,
+          5,
+          6
+        ]
       },
-      "result": "sports ",
+      "result": "a1 a2 a3 b4 b5 b6 ",
       "tags": [
         "for tag"
       ]
     },
     {
-      "name": "tags, for, offset",
-      "template": "{% for tag in product.tags offset:1 %}{{ tag }} {% endfor %}",
+      "name": "tags, for, continue a loop over a changing array",
+      "template": "{% assign foo = '1,2,3,4,5,6' | split: ',' %}{% for item in foo limit: 3 %}{{ item }} {% endfor %}{% assign foo = 'u,v,w,x,y,z' | split: ',' %}{% for item in foo offset: continue %}{{ item }} {% endfor %}",
+      "result": "1 2 3 x y z ",
+      "tags": [
+        "assign tag",
+        "for tag",
+        "split filter"
+      ]
+    },
+    {
+      "name": "tags, for, continue a loop over an assigned range",
+      "template": "{% assign nums = (1..5) %}{% for item in nums limit: 3 %}a{{ item }} {% endfor %}{% for item in nums offset: continue %}b{{ item }} {% endfor %}",
+      "result": "a1 a2 a3 b4 b5 ",
+      "tags": [
+        "assign tag",
+        "for tag"
+      ]
+    },
+    {
+      "name": "tags, for, continue from a limit that is greater than length",
+      "template": "{% for item in array limit: 99 %}a{{ item }} {% endfor %}{% for item in array offset: continue %}b{{ item }} {% endfor %}",
+      "data": {
+        "array": [
+          1,
+          2,
+          3,
+          4,
+          5,
+          6
+        ]
+      },
+      "result": "a1 a2 a3 a4 a5 a6 ",
+      "tags": [
+        "for tag"
+      ]
+    },
+    {
+      "name": "tags, for, continue from a range expression",
+      "template": "{% for item in (1..6) limit: 3 %}a{{ item }} {% endfor %}{% for item in (1..6) offset: continue %}b{{ item }} {% endfor %}",
+      "data": {
+        "array": [
+          1,
+          2,
+          3,
+          4,
+          5,
+          6
+        ]
+      },
+      "result": "a1 a2 a3 b4 b5 b6 ",
+      "tags": [
+        "for tag"
+      ]
+    },
+    {
+      "name": "tags, for, continue with changing loop var",
+      "template": "{% for foo in array limit: 3 %}{{ foo }} {% endfor %}{% for bar in array offset: continue %}{{ bar }} {% endfor %}",
+      "data": {
+        "array": [
+          1,
+          2,
+          3,
+          4,
+          5,
+          6
+        ]
+      },
+      "result": "1 2 3 1 2 3 4 5 6 ",
+      "tags": [
+        "for tag"
+      ]
+    },
+    {
+      "name": "tags, for, empty array with default",
+      "template": "{% for img in emptythings.array %}{{ img.url }} {% else %}no images{% endfor %}",
+      "data": {
+        "emptythings": {
+          "array": [],
+          "map": {},
+          "string": ""
+        }
+      },
+      "result": "no images",
+      "tags": [
+        "for tag"
+      ]
+    },
+    {
+      "name": "tags, for, first and last with an offset and limit",
+      "template": "{% for tag in tags limit: 2 offset: 1 %}{{ tag }} {{ forloop.first }} {{ forloop.last }} {% endfor %}",
+      "data": {
+        "tags": [
+          "sports",
+          "garden",
+          "home",
+          "diy",
+          "motoring",
+          "fashion"
+        ]
+      },
+      "result": "garden true false home false true ",
+      "tags": [
+        "for tag"
+      ]
+    },
+    {
+      "name": "tags, for, first and last with offset continue",
+      "template": "{% for tag in product.tags limit: 1 %}{% endfor %}{% for tag in product.tags offset: continue %}{{ forloop.first }} {{ forloop.last }} {% endfor %}",
+      "data": {
+        "product": {
+          "tags": [
+            "sports",
+            "garden",
+            "home",
+            "diy",
+            "motoring",
+            "fashion"
+          ]
+        }
+      },
+      "result": "true false false false false false false false false true ",
+      "tags": [
+        "for tag"
+      ]
+    },
+    {
+      "name": "tags, for, forloop goes out of scope",
+      "template": "{% for tag in product.tags %}{{ forloop.length }} {% endfor %}{{ forloop.length }}",
       "data": {
         "product": {
           "tags": [
@@ -8356,7 +8439,7 @@
           ]
         }
       },
-      "result": "garden ",
+      "result": "2 2 ",
       "tags": [
         "for tag"
       ]
@@ -8414,118 +8497,6 @@
       ]
     },
     {
-      "name": "tags, for, forloop goes out of scope",
-      "template": "{% for tag in product.tags %}{{ forloop.length }} {% endfor %}{{ forloop.length }}",
-      "data": {
-        "product": {
-          "tags": [
-            "sports",
-            "garden"
-          ]
-        }
-      },
-      "result": "2 2 ",
-      "tags": [
-        "for tag"
-      ]
-    },
-    {
-      "name": "tags, for, forloop.first",
-      "template": "{% for tag in product.tags %}{{ forloop.first }} {% endfor %}",
-      "data": {
-        "product": {
-          "tags": [
-            "sports",
-            "garden"
-          ]
-        }
-      },
-      "result": "true false ",
-      "tags": [
-        "for tag"
-      ]
-    },
-    {
-      "name": "tags, for, forloop.last",
-      "template": "{% for tag in product.tags %}{{ forloop.last }} {% endfor %}",
-      "data": {
-        "product": {
-          "tags": [
-            "sports",
-            "garden"
-          ]
-        }
-      },
-      "result": "false true ",
-      "tags": [
-        "for tag"
-      ]
-    },
-    {
-      "name": "tags, for, forloop.index",
-      "template": "{% for tag in product.tags %}{{ forloop.index }} {% endfor %}",
-      "data": {
-        "product": {
-          "tags": [
-            "sports",
-            "garden"
-          ]
-        }
-      },
-      "result": "1 2 ",
-      "tags": [
-        "for tag"
-      ]
-    },
-    {
-      "name": "tags, for, forloop.index0",
-      "template": "{% for tag in product.tags %}{{ forloop.index0 }} {% endfor %}",
-      "data": {
-        "product": {
-          "tags": [
-            "sports",
-            "garden"
-          ]
-        }
-      },
-      "result": "0 1 ",
-      "tags": [
-        "for tag"
-      ]
-    },
-    {
-      "name": "tags, for, forloop.rindex",
-      "template": "{% for tag in product.tags %}{{ forloop.rindex }} {% endfor %}",
-      "data": {
-        "product": {
-          "tags": [
-            "sports",
-            "garden"
-          ]
-        }
-      },
-      "result": "2 1 ",
-      "tags": [
-        "for tag"
-      ]
-    },
-    {
-      "name": "tags, for, forloop.rindex0",
-      "template": "{% for tag in product.tags %}{{ forloop.rindex0 }} {% endfor %}",
-      "data": {
-        "product": {
-          "tags": [
-            "sports",
-            "garden"
-          ]
-        }
-      },
-      "result": "1 0 ",
-      "tags": [
-        "for tag"
-      ]
-    },
-    {
       "name": "tags, for, forloop name",
       "template": "{% for tag in product.tags limit:1 %}{{ forloop.name }}{% endfor %}",
       "data": {
@@ -8566,6 +8537,102 @@
       ]
     },
     {
+      "name": "tags, for, forloop.first",
+      "template": "{% for tag in product.tags %}{{ forloop.first }} {% endfor %}",
+      "data": {
+        "product": {
+          "tags": [
+            "sports",
+            "garden"
+          ]
+        }
+      },
+      "result": "true false ",
+      "tags": [
+        "for tag"
+      ]
+    },
+    {
+      "name": "tags, for, forloop.index",
+      "template": "{% for tag in product.tags %}{{ forloop.index }} {% endfor %}",
+      "data": {
+        "product": {
+          "tags": [
+            "sports",
+            "garden"
+          ]
+        }
+      },
+      "result": "1 2 ",
+      "tags": [
+        "for tag"
+      ]
+    },
+    {
+      "name": "tags, for, forloop.index0",
+      "template": "{% for tag in product.tags %}{{ forloop.index0 }} {% endfor %}",
+      "data": {
+        "product": {
+          "tags": [
+            "sports",
+            "garden"
+          ]
+        }
+      },
+      "result": "0 1 ",
+      "tags": [
+        "for tag"
+      ]
+    },
+    {
+      "name": "tags, for, forloop.last",
+      "template": "{% for tag in product.tags %}{{ forloop.last }} {% endfor %}",
+      "data": {
+        "product": {
+          "tags": [
+            "sports",
+            "garden"
+          ]
+        }
+      },
+      "result": "false true ",
+      "tags": [
+        "for tag"
+      ]
+    },
+    {
+      "name": "tags, for, forloop.rindex",
+      "template": "{% for tag in product.tags %}{{ forloop.rindex }} {% endfor %}",
+      "data": {
+        "product": {
+          "tags": [
+            "sports",
+            "garden"
+          ]
+        }
+      },
+      "result": "2 1 ",
+      "tags": [
+        "for tag"
+      ]
+    },
+    {
+      "name": "tags, for, forloop.rindex0",
+      "template": "{% for tag in product.tags %}{{ forloop.rindex0 }} {% endfor %}",
+      "data": {
+        "product": {
+          "tags": [
+            "sports",
+            "garden"
+          ]
+        }
+      },
+      "result": "1 0 ",
+      "tags": [
+        "for tag"
+      ]
+    },
+    {
       "name": "tags, for, iterate an empty array",
       "template": "{% for item in emptythings.array %}{{ item }}{% endfor %}",
       "data": {
@@ -8596,6 +8663,53 @@
       ]
     },
     {
+      "name": "tags, for, limit",
+      "template": "{% for tag in product.tags limit:1 %}{{ tag }} {% endfor %}",
+      "data": {
+        "product": {
+          "tags": [
+            "sports",
+            "garden"
+          ]
+        }
+      },
+      "result": "sports ",
+      "tags": [
+        "for tag"
+      ]
+    },
+    {
+      "name": "tags, for, limit is a non-number string",
+      "template": "{% for i in (1..4) limit: 'foo' %}{{ i }} {% endfor %}",
+      "invalid": true,
+      "tags": [
+        "for tag"
+      ]
+    },
+    {
+      "name": "tags, for, limit is a string",
+      "template": "{% for i in (1..4) limit: '2' %}{{ i }} {% endfor %}",
+      "result": "1 2 ",
+      "tags": [
+        "for tag"
+      ]
+    },
+    {
+      "name": "tags, for, limit is not a string or number",
+      "template": "{% for i in (1..4) limit: foo %}{{ i }} {% endfor %}",
+      "data": {
+        "foo": [
+          1,
+          2,
+          3
+        ]
+      },
+      "invalid": true,
+      "tags": [
+        "for tag"
+      ]
+    },
+    {
       "name": "tags, for, lookup a filter from an outer context",
       "template": "{% for tag in product.tags %}{{ tag | upcase }} {% endfor %}",
       "data": {
@@ -8613,8 +8727,27 @@
       ]
     },
     {
-      "name": "tags, for, assign inside loop",
-      "template": "{% for tag in product.tags %}{% assign x = tag %}{% endfor %}{{ x }}",
+      "name": "tags, for, loop over a string literal",
+      "template": "{% for i in 'hello' %}{{ i }} {% endfor %}",
+      "result": "hello ",
+      "tags": [
+        "for tag"
+      ]
+    },
+    {
+      "name": "tags, for, loop over a string variable",
+      "template": "{% for i in foo %}{{ i }} {% endfor %}",
+      "data": {
+        "foo": "hello"
+      },
+      "result": "hello ",
+      "tags": [
+        "for tag"
+      ]
+    },
+    {
+      "name": "tags, for, loop over an array in reverse",
+      "template": "{% for tag in product.tags reversed %}{{ tag }} {% endfor %}",
       "data": {
         "product": {
           "tags": [
@@ -8623,18 +8756,19 @@
           ]
         }
       },
-      "result": "garden",
+      "result": "garden sports ",
       "tags": [
-        "assign tag",
         "for tag"
       ]
     },
     {
-      "name": "tags, for, blank empty loops",
-      "template": "{% for i in (0..10) %}  {% endfor %}",
-      "result": "",
+      "name": "tags, for, loop over an existing range object",
+      "template": "{% assign foo = (1..3) %}{{ foo | join: '#' }}{% for i in foo %}{{ i }}{% endfor %}{% for i in foo %}{{ i }}{% endfor %}",
+      "result": "1#2#3123123",
       "tags": [
-        "for tag"
+        "assign tag",
+        "for tag",
+        "join filter"
       ]
     },
     {
@@ -8661,64 +8795,18 @@
       ]
     },
     {
+      "name": "tags, for, loop over range with float start",
+      "template": "{% assign x = (2.4..5) %}{% for i in x %}{{ i }}{% endfor %}",
+      "result": "2345",
+      "tags": [
+        "assign tag",
+        "for tag"
+      ]
+    },
+    {
       "name": "tags, for, loop over undefined",
       "template": "{% for tag in nosuchthing %}{{ tag }}{% endfor %}",
       "result": "",
-      "tags": [
-        "for tag"
-      ]
-    },
-    {
-      "name": "tags, for, continue a loop",
-      "template": "{% for item in array limit: 3 %}a{{ item }} {% endfor %}{% for item in array offset: continue %}b{{ item }} {% endfor %}",
-      "data": {
-        "array": [
-          1,
-          2,
-          3,
-          4,
-          5,
-          6
-        ]
-      },
-      "result": "a1 a2 a3 b4 b5 b6 ",
-      "tags": [
-        "for tag"
-      ]
-    },
-    {
-      "name": "tags, for, continue a loop over an assigned range",
-      "template": "{% assign nums = (1..5) %}{% for item in nums limit: 3 %}a{{ item }} {% endfor %}{% for item in nums offset: continue %}b{{ item }} {% endfor %}",
-      "result": "a1 a2 a3 b4 b5 ",
-      "tags": [
-        "assign tag",
-        "for tag"
-      ]
-    },
-    {
-      "name": "tags, for, continue a loop over a changing array",
-      "template": "{% assign foo = '1,2,3,4,5,6' | split: ',' %}{% for item in foo limit: 3 %}{{ item }} {% endfor %}{% assign foo = 'u,v,w,x,y,z' | split: ',' %}{% for item in foo offset: continue %}{{ item }} {% endfor %}",
-      "result": "1 2 3 x y z ",
-      "tags": [
-        "assign tag",
-        "for tag",
-        "split filter"
-      ]
-    },
-    {
-      "name": "tags, for, continue with changing loop var",
-      "template": "{% for foo in array limit: 3 %}{{ foo }} {% endfor %}{% for bar in array offset: continue %}{{ bar }} {% endfor %}",
-      "data": {
-        "array": [
-          1,
-          2,
-          3,
-          4,
-          5,
-          6
-        ]
-      },
-      "result": "1 2 3 1 2 3 4 5 6 ",
       "tags": [
         "for tag"
       ]
@@ -8742,79 +8830,43 @@
       ]
     },
     {
-      "name": "tags, for, offset continue without preceding loop",
-      "template": "{% for item in array offset: continue %}{{ item }} {% endfor %}",
+      "name": "tags, for, offset",
+      "template": "{% for tag in product.tags offset:1 %}{{ tag }} {% endfor %}",
       "data": {
-        "array": [
-          1,
-          2,
-          3,
-          4,
-          5,
-          6
+        "product": {
+          "tags": [
+            "sports",
+            "garden"
+          ]
+        }
+      },
+      "result": "garden ",
+      "tags": [
+        "for tag"
+      ]
+    },
+    {
+      "name": "tags, for, offset and limit",
+      "template": "{% for tag in tags limit: 3 offset: 1 %}{{ tag }} {% endfor %}",
+      "data": {
+        "tags": [
+          "sports",
+          "garden",
+          "home",
+          "diy",
+          "motoring",
+          "fashion"
         ]
       },
-      "result": "1 2 3 4 5 6 ",
+      "result": "garden home diy ",
       "tags": [
         "for tag"
       ]
     },
     {
-      "name": "tags, for, continue from a limit that is greater than length",
-      "template": "{% for item in array limit: 99 %}a{{ item }} {% endfor %}{% for item in array offset: continue %}b{{ item }} {% endfor %}",
-      "data": {
-        "array": [
-          1,
-          2,
-          3,
-          4,
-          5,
-          6
-        ]
-      },
-      "result": "a1 a2 a3 a4 a5 a6 ",
-      "tags": [
-        "for tag"
-      ]
-    },
-    {
-      "name": "tags, for, continue from a range expression",
-      "template": "{% for item in (1..6) limit: 3 %}a{{ item }} {% endfor %}{% for item in (1..6) offset: continue %}b{{ item }} {% endfor %}",
-      "data": {
-        "array": [
-          1,
-          2,
-          3,
-          4,
-          5,
-          6
-        ]
-      },
-      "result": "a1 a2 a3 b4 b5 b6 ",
-      "tags": [
-        "for tag"
-      ]
-    },
-    {
-      "name": "tags, for, offset continue twice with limit",
-      "template": "{% for item in (1..6) limit: 2 %}a{{ item }} {% endfor %}{% for item in (1..6) limit: 2 offset: continue %}b{{ item }} {% endfor %}{% for item in (1..6) offset: continue %}c{{ item }} {% endfor %}",
-      "result": "a1 a2 b3 b4 c5 c6 ",
-      "tags": [
-        "for tag"
-      ]
-    },
-    {
-      "name": "tags, for, offset continue twice with changing limit",
-      "template": "{% for item in (1..6) limit: 2 %}a{{ item }} {% endfor %}{% for item in (1..6) limit: 3 offset: continue %}b{{ item }} {% endfor %}{% for item in (1..6) offset: continue %}c{{ item }} {% endfor %}",
-      "result": "a1 a2 b3 b4 b5 c6 ",
-      "tags": [
-        "for tag"
-      ]
-    },
-    {
-      "name": "tags, for, offset continue twice with no second limit",
-      "template": "{% for item in (1..6) limit: 2 %}a{{ item }} {% endfor %}{% for item in (1..6) offset: continue %}b{{ item }} {% endfor %}{% for item in (1..6) offset: continue %}c{{ item }} {% endfor %}",
-      "result": "a1 a2 b3 b4 b5 b6 ",
+      "name": "tags, for, offset continue forloop length",
+      "template": "{% for item in (1..6) limit: 2 %}a{{ item }} - {{ forloop.length }}, {% endfor %}{% for item in (1..6) offset: continue %}b{{ item }} - {{ forloop.length }}, {% endfor %}",
+      "result": "a1 - 2, a2 - 2, b3 - 4, b4 - 4, b5 - 4, b6 - 4, ",
       "tags": [
         "for tag"
       ]
@@ -8840,33 +8892,74 @@
       ]
     },
     {
-      "name": "tags, for, offset continue forloop length",
-      "template": "{% for item in (1..6) limit: 2 %}a{{ item }} - {{ forloop.length }}, {% endfor %}{% for item in (1..6) offset: continue %}b{{ item }} - {{ forloop.length }}, {% endfor %}",
-      "result": "a1 - 2, a2 - 2, b3 - 4, b4 - 4, b5 - 4, b6 - 4, ",
+      "name": "tags, for, offset continue twice with changing limit",
+      "template": "{% for item in (1..6) limit: 2 %}a{{ item }} {% endfor %}{% for item in (1..6) limit: 3 offset: continue %}b{{ item }} {% endfor %}{% for item in (1..6) offset: continue %}c{{ item }} {% endfor %}",
+      "result": "a1 a2 b3 b4 b5 c6 ",
       "tags": [
         "for tag"
       ]
     },
     {
-      "name": "tags, for, parentloop is normally undefined",
-      "template": "{% for i in (1..2)%}{{ forloop.parentloop.index }}{% endfor %}",
-      "result": "",
+      "name": "tags, for, offset continue twice with limit",
+      "template": "{% for item in (1..6) limit: 2 %}a{{ item }} {% endfor %}{% for item in (1..6) limit: 2 offset: continue %}b{{ item }} {% endfor %}{% for item in (1..6) offset: continue %}c{{ item }} {% endfor %}",
+      "result": "a1 a2 b3 b4 c5 c6 ",
       "tags": [
         "for tag"
       ]
     },
     {
-      "name": "tags, for, access parentloop",
-      "template": "{% for i in (1..2)%}{% for j in (1..2) %}{{ i }} {{j}} {{ forloop.parentloop.index }} {{ forloop.index }} {% endfor %}{% endfor %}",
-      "result": "1 1 1 1 1 2 1 2 2 1 2 1 2 2 2 2 ",
+      "name": "tags, for, offset continue twice with no second limit",
+      "template": "{% for item in (1..6) limit: 2 %}a{{ item }} {% endfor %}{% for item in (1..6) offset: continue %}b{{ item }} {% endfor %}{% for item in (1..6) offset: continue %}c{{ item }} {% endfor %}",
+      "result": "a1 a2 b3 b4 b5 b6 ",
       "tags": [
         "for tag"
       ]
     },
     {
-      "name": "tags, for, parentloop goes out of scope",
-      "template": "{% for i in (1..2)%}{% for j in (1..2) %}{{ i }} {{ j }} {% endfor %}{{ forloop.parentloop.index }}{% endfor %}",
-      "result": "1 1 1 2 2 1 2 2 ",
+      "name": "tags, for, offset continue without preceding loop",
+      "template": "{% for item in array offset: continue %}{{ item }} {% endfor %}",
+      "data": {
+        "array": [
+          1,
+          2,
+          3,
+          4,
+          5,
+          6
+        ]
+      },
+      "result": "1 2 3 4 5 6 ",
+      "tags": [
+        "for tag"
+      ]
+    },
+    {
+      "name": "tags, for, offset is a non-number string",
+      "template": "{% for i in (1..4) offset: 'foo' %}{{ i }} {% endfor %}",
+      "invalid": true,
+      "tags": [
+        "for tag"
+      ]
+    },
+    {
+      "name": "tags, for, offset is a string",
+      "template": "{% for i in (1..4) offset: '2' %}{{ i }} {% endfor %}",
+      "result": "3 4 ",
+      "tags": [
+        "for tag"
+      ]
+    },
+    {
+      "name": "tags, for, offset is not a string or number",
+      "template": "{% for i in (1..4) offset: foo %}{{ i }} {% endfor %}",
+      "data": {
+        "foo": [
+          1,
+          2,
+          3
+        ]
+      },
+      "invalid": true,
       "tags": [
         "for tag"
       ]
@@ -8880,85 +8973,34 @@
       ]
     },
     {
-      "name": "tags, for, loop over an existing range object",
-      "template": "{% assign foo = (1..3) %}{{ foo | join: '#' }}{% for i in foo %}{{ i }}{% endfor %}{% for i in foo %}{{ i }}{% endfor %}",
-      "result": "1#2#3123123",
-      "tags": [
-        "assign tag",
-        "for tag",
-        "join filter"
-      ]
-    },
-    {
-      "name": "tags, for, loop over range with float start",
-      "template": "{% assign x = (2.4..5) %}{% for i in x %}{{ i }}{% endfor %}",
-      "result": "2345",
-      "tags": [
-        "assign tag",
-        "for tag"
-      ]
-    },
-    {
-      "name": "tags, for, share outer scope",
-      "template": "{% assign foo = 'hello' %}{% for x in (1..3) %}{% assign foo = x %}{% endfor %}{{ foo }}",
-      "result": "3",
-      "tags": [
-        "assign tag",
-        "for tag"
-      ]
-    },
-    {
-      "name": "tags, for, offset and limit",
-      "template": "{% for tag in tags limit: 3 offset: 1 %}{{ tag }} {% endfor %}",
-      "data": {
-        "tags": [
-          "sports",
-          "garden",
-          "home",
-          "diy",
-          "motoring",
-          "fashion"
-        ]
-      },
-      "result": "garden home diy ",
+      "name": "tags, for, parentloop goes out of scope",
+      "template": "{% for i in (1..2)%}{% for j in (1..2) %}{{ i }} {{ j }} {% endfor %}{{ forloop.parentloop.index }}{% endfor %}",
+      "result": "1 1 1 2 2 1 2 2 ",
       "tags": [
         "for tag"
       ]
     },
     {
-      "name": "tags, for, first and last with an offset and limit",
-      "template": "{% for tag in tags limit: 2 offset: 1 %}{{ tag }} {{ forloop.first }} {{ forloop.last }} {% endfor %}",
-      "data": {
-        "tags": [
-          "sports",
-          "garden",
-          "home",
-          "diy",
-          "motoring",
-          "fashion"
-        ]
-      },
-      "result": "garden true false home false true ",
+      "name": "tags, for, parentloop is normally undefined",
+      "template": "{% for i in (1..2)%}{{ forloop.parentloop.index }}{% endfor %}",
+      "result": "",
       "tags": [
         "for tag"
       ]
     },
     {
-      "name": "tags, for, first and last with offset continue",
-      "template": "{% for tag in product.tags limit: 1 %}{% endfor %}{% for tag in product.tags offset: continue %}{{ forloop.first }} {{ forloop.last }} {% endfor %}",
+      "name": "tags, for, range loop using identifier",
+      "template": "{% for i in (0..product.end_range) %}{{ i }} - {{ product.tags[i] }} {% endfor %}",
       "data": {
         "product": {
           "tags": [
             "sports",
-            "garden",
-            "home",
-            "diy",
-            "motoring",
-            "fashion"
-          ]
+            "garden"
+          ],
+          "end_range": 1
         }
       },
-      "result": "true false false false false false false false false true ",
+      "result": "0 - sports 1 - garden ",
       "tags": [
         "for tag"
       ]
@@ -8980,71 +9022,48 @@
       ]
     },
     {
-      "name": "tags, for, limit is a string",
-      "template": "{% for i in (1..4) limit: '2' %}{{ i }} {% endfor %}",
-      "result": "1 2 ",
+      "name": "tags, for, share outer scope",
+      "template": "{% assign foo = 'hello' %}{% for x in (1..3) %}{% assign foo = x %}{% endfor %}{{ foo }}",
+      "result": "3",
       "tags": [
+        "assign tag",
         "for tag"
       ]
     },
     {
-      "name": "tags, for, offset is a string",
-      "template": "{% for i in (1..4) offset: '2' %}{{ i }} {% endfor %}",
-      "result": "3 4 ",
-      "tags": [
-        "for tag"
-      ]
-    },
-    {
-      "name": "tags, for, limit is a non-number string",
-      "template": "{% for i in (1..4) limit: 'foo' %}{{ i }} {% endfor %}",
-      "invalid": true,
-      "tags": [
-        "for tag"
-      ]
-    },
-    {
-      "name": "tags, for, offset is a non-number string",
-      "template": "{% for i in (1..4) offset: 'foo' %}{{ i }} {% endfor %}",
-      "invalid": true,
-      "tags": [
-        "for tag"
-      ]
-    },
-    {
-      "name": "tags, for, limit is not a string or number",
-      "template": "{% for i in (1..4) limit: foo %}{{ i }} {% endfor %}",
+      "name": "tags, for, simple array loop",
+      "template": "{% for tag in product.tags %}{{ tag }} {% endfor %}",
       "data": {
-        "foo": [
-          1,
-          2,
-          3
-        ]
+        "product": {
+          "tags": [
+            "sports",
+            "garden"
+          ]
+        }
       },
-      "invalid": true,
+      "result": "sports garden ",
       "tags": [
         "for tag"
       ]
     },
     {
-      "name": "tags, for, offset is not a string or number",
-      "template": "{% for i in (1..4) offset: foo %}{{ i }} {% endfor %}",
+      "name": "tags, for, simple hash loop",
+      "template": "{% for c in collection %}{{ c[0] }} {{ c[1] }} {% endfor %}",
       "data": {
-        "foo": [
-          1,
-          2,
-          3
-        ]
+        "collection": {
+          "title": "foo",
+          "description": "bar"
+        }
       },
-      "invalid": true,
+      "result": "title foo description bar ",
       "tags": [
         "for tag"
       ]
     },
     {
-      "name": "tags, for, comma separated arguments",
-      "template": "{% for i in (1..6), limit: 4, offset: 2 %}{{ i }} {% endfor %}",
-      "result": "3 4 5 6 ",
+      "name": "tags, for, simple range loop",
+      "template": "{% for i in (0..3) %}{{ i }} {% endfor %}",
+      "result": "0 1 2 3 ",
       "tags": [
         "for tag"
       ]
@@ -9058,166 +9077,9 @@
       ]
     },
     {
-      "name": "tags, for, loop over a string literal",
-      "template": "{% for i in 'hello' %}{{ i }} {% endfor %}",
-      "result": "hello ",
-      "tags": [
-        "for tag"
-      ]
-    },
-    {
-      "name": "tags, for, loop over a string variable",
-      "template": "{% for i in foo %}{{ i }} {% endfor %}",
-      "data": {
-        "foo": "hello"
-      },
-      "result": "hello ",
-      "tags": [
-        "for tag"
-      ]
-    },
-    {
-      "name": "tags, if, condition with literal consequence",
-      "template": "{% if product.title == 'foo' %}bar{% endif %}",
-      "data": {
-        "product": {
-          "title": "foo"
-        }
-      },
-      "result": "bar",
-      "tags": [
-        "if tag"
-      ]
-    },
-    {
-      "name": "tags, if, condition with literal consequence and literal alternative",
-      "template": "{% if product.title == 'hello' %}bar{% else %}baz{% endif %}",
-      "data": {
-        "product": {
-          "title": "foo"
-        }
-      },
-      "result": "baz",
-      "tags": [
-        "if tag"
-      ]
-    },
-    {
-      "name": "tags, if, condition with conditional alternative",
-      "template": "{% if product.title == 'hello' %}foo{% elsif product.title == 'foo' %}bar{% endif %}",
-      "data": {
-        "product": {
-          "title": "foo"
-        }
-      },
-      "result": "bar",
-      "tags": [
-        "if tag"
-      ]
-    },
-    {
-      "name": "tags, if, condition with conditional alternative and final alternative",
-      "template": "{% if product.title == 'hello' %}foo{% elsif product.title == 'goodbye' %}bar{% else %}baz{% endif %}",
-      "data": {
-        "product": {
-          "title": "foo"
-        }
-      },
-      "result": "baz",
-      "tags": [
-        "if tag"
-      ]
-    },
-    {
-      "name": "tags, if, non-empty hash is truthy",
-      "template": "{% if product %}bar{% else %}foo{% endif %}",
-      "data": {
-        "product": {
-          "title": "foo"
-        }
-      },
-      "result": "bar",
-      "tags": [
-        "if tag"
-      ]
-    },
-    {
-      "name": "tags, if, literal nil is falsy",
-      "template": "{% if nil %}bar{% else %}foo{% endif %}",
-      "result": "foo",
-      "tags": [
-        "if tag"
-      ]
-    },
-    {
-      "name": "tags, if, undefined variables are falsy",
-      "template": "{% if nosuchthing %}bar{% else %}foo{% endif %}",
-      "result": "foo",
-      "tags": [
-        "if tag"
-      ]
-    },
-    {
-      "name": "tags, if, nested condition in the consequence block",
-      "template": "{% if product %}{% if title == 'Hello' %}baz{% endif %}{% endif %}",
-      "data": {
-        "product": {
-          "title": "foo"
-        },
-        "title": "Hello"
-      },
-      "result": "baz",
-      "tags": [
-        "if tag"
-      ]
-    },
-    {
-      "name": "tags, if, nested condition, alternative in the consequence block",
-      "template": "{% if product %}{% if title == 'goodbye' %}baz{% else %}hello{% endif %}{% endif %}",
-      "data": {
-        "product": {
-          "title": "foo"
-        },
-        "title": "Hello"
-      },
-      "result": "hello",
-      "tags": [
-        "if tag"
-      ]
-    },
-    {
-      "name": "tags, if, literal false condition",
-      "template": "{% if false %}{% endif %}",
-      "result": "",
-      "tags": [
-        "if tag"
-      ]
-    },
-    {
-      "name": "tags, if, contains condition",
-      "template": "{% if product.tags contains 'garden' %}baz{% endif %}",
-      "data": {
-        "product": {
-          "tags": [
-            "sports",
-            "garden"
-          ]
-        }
-      },
-      "result": "baz",
-      "tags": [
-        "if tag"
-      ]
-    },
-    {
-      "name": "tags, if, not equal condition",
-      "template": "{% if product.title != 'foo' %}baz{% endif %}",
-      "data": {
-        "product": {
-          "title": "foo"
-        }
-      },
-      "result": "",
+      "name": "tags, if, 0.0 is truthy",
+      "template": "{% if 0.0 %}Hello{% else %}Goodbye{% endif %}",
+      "result": "Hello",
       "tags": [
         "if tag"
       ]
@@ -9236,75 +9098,48 @@
       ]
     },
     {
-      "name": "tags, if, blocks that contain only whitespace are not rendered",
-      "template": "{% if true %}  {% elsif false %} {% else %} {% endif %}",
-      "result": "",
+      "name": "tags, if, array contains false",
+      "template": "{% if a contains false %}TRUE{% else %}FALSE{% endif %}",
+      "data": {
+        "a": [
+          1,
+          2,
+          3,
+          false
+        ]
+      },
+      "result": "FALSE",
       "tags": [
         "if tag"
       ]
     },
     {
-      "name": "tags, if, blocks that contain only whitespace and comments are not rendered",
-      "template": "{% if true %} {% comment %} this is blank {% endcomment %} {% endif %}",
-      "result": "",
-      "tags": [
-        "comment tag",
-        "if tag"
-      ]
-    },
-    {
-      "name": "tags, if, conditional alternative with default",
-      "template": "{% if false %}foo{% elsif false %}bar{% else %}hello{% endif %}",
-      "result": "hello",
+      "name": "tags, if, array contains nil",
+      "template": "{% if a contains nil %}TRUE{% else %}FALSE{% endif %}",
+      "data": {
+        "a": [
+          1,
+          2,
+          null
+        ]
+      },
+      "result": "FALSE",
       "tags": [
         "if tag"
       ]
     },
     {
-      "name": "tags, if, range equals range",
-      "template": "{% assign foo = (1..3) %}{% if foo == (1..3) %}true{% else %}false{% endif %}",
-      "result": "true",
-      "tags": [
-        "assign tag",
-        "if tag"
-      ]
-    },
-    {
-      "name": "tags, if, logical operators are right associative",
-      "template": "{% if true and false and false or true %}hello{% endif %}",
-      "result": "",
-      "tags": [
-        "if tag"
-      ]
-    },
-    {
-      "name": "tags, if, zero is not equal to false",
-      "template": "{% if 0 == false %}Hello{% else %}Goodbye{% endif %}",
-      "result": "Goodbye",
-      "tags": [
-        "if tag"
-      ]
-    },
-    {
-      "name": "tags, if, zero is truthy",
-      "template": "{% if 0 %}Hello{% else %}Goodbye{% endif %}",
-      "result": "Hello",
-      "tags": [
-        "if tag"
-      ]
-    },
-    {
-      "name": "tags, if, 0.0 is truthy",
-      "template": "{% if 0.0 %}Hello{% else %}Goodbye{% endif %}",
-      "result": "Hello",
-      "tags": [
-        "if tag"
-      ]
-    },
-    {
-      "name": "tags, if, one is not equal to true",
-      "template": "{% if 1 == true %}Hello{% else %}Goodbye{% endif %}",
-      "result": "Goodbye",
+      "name": "tags, if, array contains undefined",
+      "template": "{% if a contains nosuchthing %}TRUE{% else %}FALSE{% endif %}",
+      "data": {
+        "a": [
+          1,
+          2,
+          3,
+          null
+        ]
+      },
+      "result": "FALSE",
       "tags": [
         "if tag"
       ]
@@ -9337,97 +9172,106 @@
       ]
     },
     {
-      "name": "tags, if, string does not equal int",
-      "template": "{% if '1' == 1 %}true{% else %}false{% endif %}",
-      "result": "false",
+      "name": "tags, if, blocks that contain only whitespace and comments are not rendered",
+      "template": "{% if true %} {% comment %} this is blank {% endcomment %} {% endif %}",
+      "result": "",
+      "tags": [
+        "comment tag",
+        "if tag"
+      ]
+    },
+    {
+      "name": "tags, if, blocks that contain only whitespace are not rendered",
+      "template": "{% if true %}  {% elsif false %} {% else %} {% endif %}",
+      "result": "",
       "tags": [
         "if tag"
       ]
     },
     {
-      "name": "tags, if, int does not equal string",
-      "template": "{% if 1 == '1' %}true{% else %}false{% endif %}",
-      "result": "false",
+      "name": "tags, if, condition with conditional alternative",
+      "template": "{% if product.title == 'hello' %}foo{% elsif product.title == 'foo' %}bar{% endif %}",
+      "data": {
+        "product": {
+          "title": "foo"
+        }
+      },
+      "result": "bar",
       "tags": [
         "if tag"
       ]
     },
     {
-      "name": "tags, if, int equals float",
-      "template": "{% if 1 == 1.0 %}true{% else %}false{% endif %}",
-      "result": "true",
+      "name": "tags, if, condition with conditional alternative and final alternative",
+      "template": "{% if product.title == 'hello' %}foo{% elsif product.title == 'goodbye' %}bar{% else %}baz{% endif %}",
+      "data": {
+        "product": {
+          "title": "foo"
+        }
+      },
+      "result": "baz",
       "tags": [
         "if tag"
       ]
     },
     {
-      "name": "tags, if, string greater than int",
-      "template": "{% if '2' > 1 %}true{% else %}false{% endif %}",
-      "invalid": true,
+      "name": "tags, if, condition with literal consequence",
+      "template": "{% if product.title == 'foo' %}bar{% endif %}",
+      "data": {
+        "product": {
+          "title": "foo"
+        }
+      },
+      "result": "bar",
       "tags": [
         "if tag"
       ]
     },
     {
-      "name": "tags, if, string is less than string",
-      "template": "{% if 'abc' < 'acb' %}true{% else %}false{% endif %}",
-      "result": "true",
+      "name": "tags, if, condition with literal consequence and literal alternative",
+      "template": "{% if product.title == 'hello' %}bar{% else %}baz{% endif %}",
+      "data": {
+        "product": {
+          "title": "foo"
+        }
+      },
+      "result": "baz",
       "tags": [
         "if tag"
       ]
     },
     {
-      "name": "tags, if, string is not less than string",
-      "template": "{% if 'bbb' < 'aaa' %}true{% else %}false{% endif %}",
-      "result": "false",
+      "name": "tags, if, conditional alternative with default",
+      "template": "{% if false %}foo{% elsif false %}bar{% else %}hello{% endif %}",
+      "result": "hello",
       "tags": [
         "if tag"
       ]
     },
     {
-      "name": "tags, if, string is less than or equal to string",
-      "template": "{% if 'abc' <= 'acb' %}true{% else %}false{% endif %}",
-      "result": "true",
+      "name": "tags, if, contains condition",
+      "template": "{% if product.tags contains 'garden' %}baz{% endif %}",
+      "data": {
+        "product": {
+          "tags": [
+            "sports",
+            "garden"
+          ]
+        }
+      },
+      "result": "baz",
       "tags": [
         "if tag"
       ]
     },
     {
-      "name": "tags, if, string is not less than or equal to string",
-      "template": "{% if 'bbb' <= 'aaa' %}true{% else %}false{% endif %}",
-      "result": "false",
-      "tags": [
-        "if tag"
-      ]
-    },
-    {
-      "name": "tags, if, string is greater than string",
-      "template": "{% if 'abc' > 'acb' %}true{% else %}false{% endif %}",
-      "result": "false",
-      "tags": [
-        "if tag"
-      ]
-    },
-    {
-      "name": "tags, if, string is not greater than string",
-      "template": "{% if 'bbb' > 'aaa' %}true{% else %}false{% endif %}",
-      "result": "true",
-      "tags": [
-        "if tag"
-      ]
-    },
-    {
-      "name": "tags, if, string is greater than or equal to string",
-      "template": "{% if 'abc' >= 'acb' %}true{% else %}false{% endif %}",
-      "result": "false",
-      "tags": [
-        "if tag"
-      ]
-    },
-    {
-      "name": "tags, if, string is not greater than or equal to string",
-      "template": "{% if 'bbb' >= 'aaa' %}true{% else %}false{% endif %}",
-      "result": "true",
+      "name": "tags, if, context string contains string from context",
+      "template": "{% if t contains s %}TRUE{% else %}FALSE{% endif %}",
+      "data": {
+        "s": "llo",
+        "t": "hello"
+      },
+      "result": "TRUE",
       "tags": [
         "if tag"
       ]
@@ -9435,24 +9279,6 @@
     {
       "name": "tags, if, else tag expressions are ignored",
       "template": "{% if false %}1{% else nonsense %}2{% endif %}",
-      "tags": [
-        "if tag",
-        "strict"
-      ],
-      "result": "2"
-    },
-    {
-      "name": "tags, if, extra else blocks are ignored",
-      "template": "{% if false %}1{% else %}2{% else %}3{% endif %}",
-      "tags": [
-        "if tag",
-        "strict"
-      ],
-      "result": "2"
-    },
-    {
-      "name": "tags, if, extra elsif blocks are ignored",
-      "template": "{% if false %}1{% else %}2{% elsif true %}3{% endif %}",
       "tags": [
         "if tag",
         "strict"
@@ -9512,97 +9338,174 @@
       ]
     },
     {
-      "name": "tags, if, string contains string",
-      "template": "{% if 'hello' contains 'llo' %}TRUE{% else %}FALSE{% endif %}",
-      "result": "TRUE",
-      "tags": [
-        "if tag"
-      ]
-    },
-    {
-      "name": "tags, if, string contains int",
-      "template": "{% if 'hel9lo' contains 9 %}TRUE{% else %}FALSE{% endif %}",
-      "result": "TRUE",
-      "tags": [
-        "if tag"
-      ]
-    },
-    {
-      "name": "tags, if, string contains string from context",
-      "template": "{% if 'hello' contains s %}TRUE{% else %}FALSE{% endif %}",
+      "name": "tags, if, endswith is not a valid operator",
+      "template": "{% if s endswith t %}TRUE{% else %}FALSE{% endif %}",
       "data": {
-        "s": "llo"
+        "s": "hello",
+        "t": "lo"
       },
-      "result": "TRUE",
       "tags": [
+        "absent",
         "if tag"
-      ]
+      ],
+      "invalid": true
     },
     {
-      "name": "tags, if, context string contains string from context",
-      "template": "{% if t contains s %}TRUE{% else %}FALSE{% endif %}",
+      "name": "tags, if, extra else blocks are ignored",
+      "template": "{% if false %}1{% else %}2{% else %}3{% endif %}",
+      "tags": [
+        "if tag",
+        "strict"
+      ],
+      "result": "2"
+    },
+    {
+      "name": "tags, if, extra elsif blocks are ignored",
+      "template": "{% if false %}1{% else %}2{% elsif true %}3{% endif %}",
+      "tags": [
+        "if tag",
+        "strict"
+      ],
+      "result": "2"
+    },
+    {
+      "name": "tags, if, haskey is not a valid operator",
+      "template": "{% if obj haskey x %}TRUE{% else %}FALSE{% endif %}",
       "data": {
-        "s": "llo",
-        "t": "hello"
+        "obj": {
+          "foo": "bar"
+        },
+        "x": "foo"
       },
-      "result": "TRUE",
       "tags": [
+        "absent",
         "if tag"
-      ]
+      ],
+      "invalid": true
     },
     {
-      "name": "tags, if, undefined is equal to nil",
-      "template": "{% if nosuchthing == nil %}TRUE{% else %}FALSE{% endif %}",
-      "result": "TRUE",
-      "tags": [
-        "if tag"
-      ]
-    },
-    {
-      "name": "tags, if, undefined is equal to null",
-      "template": "{% if nosuchthing == null %}TRUE{% else %}FALSE{% endif %}",
-      "result": "TRUE",
-      "tags": [
-        "if tag"
-      ]
-    },
-    {
-      "name": "tags, if, string contains undefined",
-      "template": "{% if s contains nosuchthing %}TRUE{% else %}FALSE{% endif %}",
+      "name": "tags, if, in is not a valid operator",
+      "template": "{% if t in s %}TRUE{% else %}FALSE{% endif %}",
       "data": {
-        "s": "hello"
+        "s": "hello",
+        "t": "lo"
       },
-      "result": "FALSE",
+      "tags": [
+        "absent",
+        "if tag"
+      ],
+      "invalid": true
+    },
+    {
+      "name": "tags, if, int does not equal string",
+      "template": "{% if 1 == '1' %}true{% else %}false{% endif %}",
+      "result": "false",
       "tags": [
         "if tag"
       ]
     },
     {
-      "name": "tags, if, array contains undefined",
-      "template": "{% if a contains nosuchthing %}TRUE{% else %}FALSE{% endif %}",
+      "name": "tags, if, int equals float",
+      "template": "{% if 1 == 1.0 %}true{% else %}false{% endif %}",
+      "result": "true",
+      "tags": [
+        "if tag"
+      ]
+    },
+    {
+      "name": "tags, if, literal false condition",
+      "template": "{% if false %}{% endif %}",
+      "result": "",
+      "tags": [
+        "if tag"
+      ]
+    },
+    {
+      "name": "tags, if, literal nil is falsy",
+      "template": "{% if nil %}bar{% else %}foo{% endif %}",
+      "result": "foo",
+      "tags": [
+        "if tag"
+      ]
+    },
+    {
+      "name": "tags, if, logical operators are right associative",
+      "template": "{% if true and false and false or true %}hello{% endif %}",
+      "result": "",
+      "tags": [
+        "if tag"
+      ]
+    },
+    {
+      "name": "tags, if, nested condition in the consequence block",
+      "template": "{% if product %}{% if title == 'Hello' %}baz{% endif %}{% endif %}",
       "data": {
-        "a": [
-          1,
-          2,
-          3,
-          null
-        ]
+        "product": {
+          "title": "foo"
+        },
+        "title": "Hello"
       },
-      "result": "FALSE",
+      "result": "baz",
       "tags": [
         "if tag"
       ]
     },
     {
-      "name": "tags, if, array contains false",
-      "template": "{% if a contains false %}TRUE{% else %}FALSE{% endif %}",
+      "name": "tags, if, nested condition, alternative in the consequence block",
+      "template": "{% if product %}{% if title == 'goodbye' %}baz{% else %}hello{% endif %}{% endif %}",
       "data": {
-        "a": [
-          1,
-          2,
-          3,
-          false
-        ]
+        "product": {
+          "title": "foo"
+        },
+        "title": "Hello"
+      },
+      "result": "hello",
+      "tags": [
+        "if tag"
+      ]
+    },
+    {
+      "name": "tags, if, non-empty hash is truthy",
+      "template": "{% if product %}bar{% else %}foo{% endif %}",
+      "data": {
+        "product": {
+          "title": "foo"
+        }
+      },
+      "result": "bar",
+      "tags": [
+        "if tag"
+      ]
+    },
+    {
+      "name": "tags, if, not equal condition",
+      "template": "{% if product.title != 'foo' %}baz{% endif %}",
+      "data": {
+        "product": {
+          "title": "foo"
+        }
+      },
+      "result": "",
+      "tags": [
+        "if tag"
+      ]
+    },
+    {
+      "name": "tags, if, not is not a valid operator",
+      "template": "{% if not false %}TRUE{% else %}FALSE{% endif %}",
+      "tags": [
+        "absent",
+        "if tag"
+      ],
+      "invalid": true
+    },
+    {
+      "name": "tags, if, object contains nil",
+      "template": "{% if obj contains nosuchthing %}TRUE{% else %}FALSE{% endif %}",
+      "data": {
+        "obj": {
+          "foo": "bar"
+        }
       },
       "result": "FALSE",
       "tags": [
@@ -9623,6 +9526,44 @@
       ]
     },
     {
+      "name": "tags, if, one is not equal to true",
+      "template": "{% if 1 == true %}Hello{% else %}Goodbye{% endif %}",
+      "result": "Goodbye",
+      "tags": [
+        "if tag"
+      ]
+    },
+    {
+      "name": "tags, if, range equals range",
+      "template": "{% assign foo = (1..3) %}{% if foo == (1..3) %}true{% else %}false{% endif %}",
+      "result": "true",
+      "tags": [
+        "assign tag",
+        "if tag"
+      ]
+    },
+    {
+      "name": "tags, if, startswith is not a valid operator",
+      "template": "{% if s startswith t %}TRUE{% else %}FALSE{% endif %}",
+      "data": {
+        "s": "hello",
+        "t": "hell"
+      },
+      "tags": [
+        "absent",
+        "if tag"
+      ],
+      "invalid": true
+    },
+    {
+      "name": "tags, if, string contains int",
+      "template": "{% if 'hel9lo' contains 9 %}TRUE{% else %}FALSE{% endif %}",
+      "result": "TRUE",
+      "tags": [
+        "if tag"
+      ]
+    },
+    {
       "name": "tags, if, string contains nil",
       "template": "{% if s contains nil %}TRUE{% else %}FALSE{% endif %}",
       "data": {
@@ -9634,40 +9575,111 @@
       ]
     },
     {
-      "name": "tags, if, array contains nil",
-      "template": "{% if a contains nil %}TRUE{% else %}FALSE{% endif %}",
-      "data": {
-        "a": [
-          1,
-          2,
-          null
-        ]
-      },
-      "result": "FALSE",
+      "name": "tags, if, string contains string",
+      "template": "{% if 'hello' contains 'llo' %}TRUE{% else %}FALSE{% endif %}",
+      "result": "TRUE",
       "tags": [
         "if tag"
       ]
     },
     {
-      "name": "tags, if, object contains nil",
-      "template": "{% if obj contains nosuchthing %}TRUE{% else %}FALSE{% endif %}",
+      "name": "tags, if, string contains string from context",
+      "template": "{% if 'hello' contains s %}TRUE{% else %}FALSE{% endif %}",
       "data": {
-        "obj": {
-          "foo": "bar"
-        }
+        "s": "llo"
       },
-      "result": "FALSE",
+      "result": "TRUE",
       "tags": [
         "if tag"
       ]
     },
     {
-      "name": "tags, if, undefined contains string",
-      "template": "{% if undefined contains s %}TRUE{% else %}FALSE{% endif %}",
+      "name": "tags, if, string contains undefined",
+      "template": "{% if s contains nosuchthing %}TRUE{% else %}FALSE{% endif %}",
       "data": {
         "s": "hello"
       },
       "result": "FALSE",
+      "tags": [
+        "if tag"
+      ]
+    },
+    {
+      "name": "tags, if, string does not equal int",
+      "template": "{% if '1' == 1 %}true{% else %}false{% endif %}",
+      "result": "false",
+      "tags": [
+        "if tag"
+      ]
+    },
+    {
+      "name": "tags, if, string greater than int",
+      "template": "{% if '2' > 1 %}true{% else %}false{% endif %}",
+      "invalid": true,
+      "tags": [
+        "if tag"
+      ]
+    },
+    {
+      "name": "tags, if, string is greater than or equal to string",
+      "template": "{% if 'abc' >= 'acb' %}true{% else %}false{% endif %}",
+      "result": "false",
+      "tags": [
+        "if tag"
+      ]
+    },
+    {
+      "name": "tags, if, string is greater than string",
+      "template": "{% if 'abc' > 'acb' %}true{% else %}false{% endif %}",
+      "result": "false",
+      "tags": [
+        "if tag"
+      ]
+    },
+    {
+      "name": "tags, if, string is less than or equal to string",
+      "template": "{% if 'abc' <= 'acb' %}true{% else %}false{% endif %}",
+      "result": "true",
+      "tags": [
+        "if tag"
+      ]
+    },
+    {
+      "name": "tags, if, string is less than string",
+      "template": "{% if 'abc' < 'acb' %}true{% else %}false{% endif %}",
+      "result": "true",
+      "tags": [
+        "if tag"
+      ]
+    },
+    {
+      "name": "tags, if, string is not greater than or equal to string",
+      "template": "{% if 'bbb' >= 'aaa' %}true{% else %}false{% endif %}",
+      "result": "true",
+      "tags": [
+        "if tag"
+      ]
+    },
+    {
+      "name": "tags, if, string is not greater than string",
+      "template": "{% if 'bbb' > 'aaa' %}true{% else %}false{% endif %}",
+      "result": "true",
+      "tags": [
+        "if tag"
+      ]
+    },
+    {
+      "name": "tags, if, string is not less than or equal to string",
+      "template": "{% if 'bbb' <= 'aaa' %}true{% else %}false{% endif %}",
+      "result": "false",
+      "tags": [
+        "if tag"
+      ]
+    },
+    {
+      "name": "tags, if, string is not less than string",
+      "template": "{% if 'bbb' < 'aaa' %}true{% else %}false{% endif %}",
+      "result": "false",
       "tags": [
         "if tag"
       ]
@@ -9701,6 +9713,17 @@
       ]
     },
     {
+      "name": "tags, if, undefined contains string",
+      "template": "{% if undefined contains s %}TRUE{% else %}FALSE{% endif %}",
+      "data": {
+        "s": "hello"
+      },
+      "result": "FALSE",
+      "tags": [
+        "if tag"
+      ]
+    },
+    {
       "name": "tags, if, undefined contains undefined",
       "template": "{% if undefined contains thing %}TRUE{% else %}FALSE{% endif %}",
       "result": "FALSE",
@@ -9709,80 +9732,58 @@
       ]
     },
     {
-      "name": "tags, if, startswith is not a valid operator",
-      "template": "{% if s startswith t %}TRUE{% else %}FALSE{% endif %}",
-      "data": {
-        "s": "hello",
-        "t": "hell"
-      },
+      "name": "tags, if, undefined is equal to nil",
+      "template": "{% if nosuchthing == nil %}TRUE{% else %}FALSE{% endif %}",
+      "result": "TRUE",
       "tags": [
-        "absent",
         "if tag"
-      ],
-      "invalid": true
+      ]
     },
     {
-      "name": "tags, if, endswith is not a valid operator",
-      "template": "{% if s endswith t %}TRUE{% else %}FALSE{% endif %}",
-      "data": {
-        "s": "hello",
-        "t": "lo"
-      },
+      "name": "tags, if, undefined is equal to null",
+      "template": "{% if nosuchthing == null %}TRUE{% else %}FALSE{% endif %}",
+      "result": "TRUE",
       "tags": [
-        "absent",
         "if tag"
-      ],
-      "invalid": true
+      ]
     },
     {
-      "name": "tags, if, haskey is not a valid operator",
-      "template": "{% if obj haskey x %}TRUE{% else %}FALSE{% endif %}",
-      "data": {
-        "obj": {
-          "foo": "bar"
-        },
-        "x": "foo"
-      },
+      "name": "tags, if, undefined variables are falsy",
+      "template": "{% if nosuchthing %}bar{% else %}foo{% endif %}",
+      "result": "foo",
       "tags": [
-        "absent",
         "if tag"
-      ],
-      "invalid": true
+      ]
     },
     {
-      "name": "tags, if, in is not a valid operator",
-      "template": "{% if t in s %}TRUE{% else %}FALSE{% endif %}",
-      "data": {
-        "s": "hello",
-        "t": "lo"
-      },
+      "name": "tags, if, zero is not equal to false",
+      "template": "{% if 0 == false %}Hello{% else %}Goodbye{% endif %}",
+      "result": "Goodbye",
       "tags": [
-        "absent",
         "if tag"
-      ],
-      "invalid": true
+      ]
     },
     {
-      "name": "tags, if, not is not a valid operator",
-      "template": "{% if not false %}TRUE{% else %}FALSE{% endif %}",
+      "name": "tags, if, zero is truthy",
+      "template": "{% if 0 %}Hello{% else %}Goodbye{% endif %}",
+      "result": "Hello",
       "tags": [
-        "absent",
         "if tag"
-      ],
-      "invalid": true
+      ]
+    },
+    {
+      "name": "tags, ifchanged, change from assign",
+      "template": "{% assign foo = 'hello' %}{% ifchanged %}{{ foo }}{% endifchanged %}{% ifchanged %}{{ foo }}{% endifchanged %}{% assign foo = 'goodbye' %}{% ifchanged %}{{ foo }}{% endifchanged %}",
+      "result": "hellogoodbye",
+      "tags": [
+        "assign tag",
+        "ifchanged tag"
+      ]
     },
     {
       "name": "tags, ifchanged, changed from initial state",
       "template": "{% ifchanged %}hello{% endifchanged %}",
       "result": "hello",
-      "tags": [
-        "ifchanged tag"
-      ]
-    },
-    {
-      "name": "tags, ifchanged, not changed from initial state",
-      "template": "{% ifchanged %}{% endifchanged %}",
-      "result": "",
       "tags": [
         "ifchanged tag"
       ]
@@ -9797,11 +9798,10 @@
       ]
     },
     {
-      "name": "tags, ifchanged, change from assign",
-      "template": "{% assign foo = 'hello' %}{% ifchanged %}{{ foo }}{% endifchanged %}{% ifchanged %}{{ foo }}{% endifchanged %}{% assign foo = 'goodbye' %}{% ifchanged %}{{ foo }}{% endifchanged %}",
-      "result": "hellogoodbye",
+      "name": "tags, ifchanged, not changed from initial state",
+      "template": "{% ifchanged %}{% endifchanged %}",
+      "result": "",
       "tags": [
-        "assign tag",
         "ifchanged tag"
       ]
     },
@@ -9818,42 +9818,51 @@
       ]
     },
     {
-      "name": "tags, include, string literal name",
-      "template": "{% include 'product-hero' %}",
+      "name": "tags, include, assign persists in outer scope",
+      "template": "{% include 'assign-outer-scope' %} {{ last_name }}",
       "data": {
-        "product": {
-          "title": "foo",
-          "tags": [
-            "sports",
-            "garden"
-          ]
+        "customer": {
+          "first_name": "Holly"
         }
       },
       "templates": {
-        "product-hero": "{{ product.title }}\n{% for tag in product.tags %}- {{ tag }}\n{% endfor %}"
+        "assign-outer-scope": "Hello, {{ customer.first_name }}{% assign last_name = 'Smith' %}"
       },
-      "result": "foo\n- sports\n- garden\n",
+      "result": "Hello, Holly Smith",
       "tags": [
         "include tag"
       ]
     },
     {
-      "name": "tags, include, name from identifier",
-      "template": "{% include snippet %}",
+      "name": "tags, include, assign to a keyword argument",
+      "template": "{% include 'product-args', foo: 'hello' %} {{ foo }}",
+      "templates": {
+        "product-args": "{{ foo }}{% assign foo = 'goodbye' %} {{ foo }}"
+      },
+      "result": "hello hello goodbye",
+      "tags": [
+        "include tag"
+      ]
+    },
+    {
+      "name": "tags, include, bound array variable",
+      "template": "{% include 'prod' for collection.products %}",
       "data": {
-        "snippet": "product-hero",
-        "product": {
-          "title": "foo",
-          "tags": [
-            "sports",
-            "garden"
+        "collection": {
+          "products": [
+            {
+              "title": "bike"
+            },
+            {
+              "title": "car"
+            }
           ]
         }
       },
       "templates": {
-        "product-hero": "{{ product.title }}\n{% for tag in product.tags %}- {{ tag }}\n{% endfor %}"
+        "prod": "{{ prod.title }}"
       },
-      "result": "foo\n- sports\n- garden\n",
+      "result": "bikecar",
       "tags": [
         "include tag"
       ]
@@ -9893,29 +9902,6 @@
       ]
     },
     {
-      "name": "tags, include, bound array variable",
-      "template": "{% include 'prod' for collection.products %}",
-      "data": {
-        "collection": {
-          "products": [
-            {
-              "title": "bike"
-            },
-            {
-              "title": "car"
-            }
-          ]
-        }
-      },
-      "templates": {
-        "prod": "{{ prod.title }}"
-      },
-      "result": "bikecar",
-      "tags": [
-        "include tag"
-      ]
-    },
-    {
       "name": "tags, include, bound variable with alias",
       "template": "{% include 'product-alias' with collection.products[1] as product %}",
       "data": {
@@ -9936,94 +9922,6 @@
       "result": "car",
       "tags": [
         "include tag"
-      ]
-    },
-    {
-      "name": "tags, include, some keyword arguments",
-      "template": "{% include 'product-args', foo: 'hello', bar: 'there' %}",
-      "templates": {
-        "product-args": "{{ foo }} {{ bar }}"
-      },
-      "result": "hello there",
-      "tags": [
-        "include tag"
-      ]
-    },
-    {
-      "name": "tags, include, some keyword arguments without leading comma",
-      "template": "{% include 'product-args' foo: 'hello', bar: 'there' %}",
-      "templates": {
-        "product-args": "{{ foo }} {{ bar }}"
-      },
-      "result": "hello there",
-      "tags": [
-        "include tag"
-      ]
-    },
-    {
-      "name": "tags, include, some keyword arguments with float literals",
-      "template": "{% include 'product-args' foo: 1.1, bar: 'there' %}",
-      "templates": {
-        "product-args": "{{ foo }} {{ bar }}"
-      },
-      "result": "1.1 there",
-      "tags": [
-        "include tag"
-      ]
-    },
-    {
-      "name": "tags, include, some keyword arguments with range literal",
-      "template": "{% include 'product-args' foo: (1..3), bar: 'there' %}",
-      "templates": {
-        "product-args": "{{ foo | join: '#' }} {{ bar }}"
-      },
-      "result": "1#2#3 there",
-      "tags": [
-        "include tag"
-      ]
-    },
-    {
-      "name": "tags, include, use globals from outer scope",
-      "template": "{% include 'outer-scope' %}",
-      "data": {
-        "customer": {
-          "first_name": "Holly"
-        }
-      },
-      "templates": {
-        "outer-scope": "Hello, {{ customer.first_name }}"
-      },
-      "result": "Hello, Holly",
-      "tags": [
-        "include tag"
-      ]
-    },
-    {
-      "name": "tags, include, assign persists in outer scope",
-      "template": "{% include 'assign-outer-scope' %} {{ last_name }}",
-      "data": {
-        "customer": {
-          "first_name": "Holly"
-        }
-      },
-      "templates": {
-        "assign-outer-scope": "Hello, {{ customer.first_name }}{% assign last_name = 'Smith' %}"
-      },
-      "result": "Hello, Holly Smith",
-      "tags": [
-        "include tag"
-      ]
-    },
-    {
-      "name": "tags, include, counter from outer scope",
-      "template": "{% increment foo %} {% include 'increment-outer-scope' %} {% increment foo %}",
-      "templates": {
-        "increment-outer-scope": "{% increment foo %}"
-      },
-      "result": "0 1 2",
-      "tags": [
-        "include tag",
-        "increment tag"
       ]
     },
     {
@@ -10068,6 +9966,18 @@
       ]
     },
     {
+      "name": "tags, include, counter from outer scope",
+      "template": "{% increment foo %} {% include 'increment-outer-scope' %} {% increment foo %}",
+      "templates": {
+        "increment-outer-scope": "{% increment foo %}"
+      },
+      "result": "0 1 2",
+      "tags": [
+        "include tag",
+        "increment tag"
+      ]
+    },
+    {
       "name": "tags, include, keyword arguments go out of scope",
       "template": "{% include 'product-args', foo: 'hello', bar: 'there' %}{{ foo }}",
       "templates": {
@@ -10079,21 +9989,112 @@
       ]
     },
     {
-      "name": "tags, include, assign to a keyword argument",
-      "template": "{% include 'product-args', foo: 'hello' %} {{ foo }}",
-      "templates": {
-        "product-args": "{{ foo }}{% assign foo = 'goodbye' %} {{ foo }}"
+      "name": "tags, include, name from identifier",
+      "template": "{% include snippet %}",
+      "data": {
+        "snippet": "product-hero",
+        "product": {
+          "title": "foo",
+          "tags": [
+            "sports",
+            "garden"
+          ]
+        }
       },
-      "result": "hello hello goodbye",
+      "templates": {
+        "product-hero": "{{ product.title }}\n{% for tag in product.tags %}- {{ tag }}\n{% endfor %}"
+      },
+      "result": "foo\n- sports\n- garden\n",
       "tags": [
         "include tag"
       ]
     },
     {
-      "name": "tags, increment, named counter",
-      "template": "{% increment foo %} {% increment foo %} {% increment foo %}",
-      "result": "0 1 2",
+      "name": "tags, include, some keyword arguments",
+      "template": "{% include 'product-args', foo: 'hello', bar: 'there' %}",
+      "templates": {
+        "product-args": "{{ foo }} {{ bar }}"
+      },
+      "result": "hello there",
       "tags": [
+        "include tag"
+      ]
+    },
+    {
+      "name": "tags, include, some keyword arguments with float literals",
+      "template": "{% include 'product-args' foo: 1.1, bar: 'there' %}",
+      "templates": {
+        "product-args": "{{ foo }} {{ bar }}"
+      },
+      "result": "1.1 there",
+      "tags": [
+        "include tag"
+      ]
+    },
+    {
+      "name": "tags, include, some keyword arguments with range literal",
+      "template": "{% include 'product-args' foo: (1..3), bar: 'there' %}",
+      "templates": {
+        "product-args": "{{ foo | join: '#' }} {{ bar }}"
+      },
+      "result": "1#2#3 there",
+      "tags": [
+        "include tag"
+      ]
+    },
+    {
+      "name": "tags, include, some keyword arguments without leading comma",
+      "template": "{% include 'product-args' foo: 'hello', bar: 'there' %}",
+      "templates": {
+        "product-args": "{{ foo }} {{ bar }}"
+      },
+      "result": "hello there",
+      "tags": [
+        "include tag"
+      ]
+    },
+    {
+      "name": "tags, include, string literal name",
+      "template": "{% include 'product-hero' %}",
+      "data": {
+        "product": {
+          "title": "foo",
+          "tags": [
+            "sports",
+            "garden"
+          ]
+        }
+      },
+      "templates": {
+        "product-hero": "{{ product.title }}\n{% for tag in product.tags %}- {{ tag }}\n{% endfor %}"
+      },
+      "result": "foo\n- sports\n- garden\n",
+      "tags": [
+        "include tag"
+      ]
+    },
+    {
+      "name": "tags, include, use globals from outer scope",
+      "template": "{% include 'outer-scope' %}",
+      "data": {
+        "customer": {
+          "first_name": "Holly"
+        }
+      },
+      "templates": {
+        "outer-scope": "Hello, {{ customer.first_name }}"
+      },
+      "result": "Hello, Holly",
+      "tags": [
+        "include tag"
+      ]
+    },
+    {
+      "name": "tags, increment, assign and increment",
+      "template": "{% assign foo = 5 %}{{ foo }} {% increment foo %} {% increment foo %} {{ foo }}",
+      "result": "5 0 1 5",
+      "tags": [
+        "assign tag",
         "increment tag"
       ]
     },
@@ -10114,11 +10115,10 @@
       ]
     },
     {
-      "name": "tags, increment, assign and increment",
-      "template": "{% assign foo = 5 %}{{ foo }} {% increment foo %} {% increment foo %} {{ foo }}",
-      "result": "5 0 1 5",
+      "name": "tags, increment, named counter",
+      "template": "{% increment foo %} {% increment foo %} {% increment foo %}",
+      "result": "0 1 2",
       "tags": [
-        "assign tag",
         "increment tag"
       ]
     },
@@ -10132,108 +10132,9 @@
       ]
     },
     {
-      "name": "tags, inline comment, with whitespace control and padding",
-      "template": "{%- # some comment -%}",
-      "result": "",
-      "tags": [
-        "# tag"
-      ]
-    },
-    {
-      "name": "tags, inline comment, with whitespace control no padding",
-      "template": "{%-# some comment -%}",
-      "result": "",
-      "tags": [
-        "# tag"
-      ]
-    },
-    {
-      "name": "tags, inline comment, no whitespace control with padding",
-      "template": "{% # some comment %}",
-      "result": "",
-      "tags": [
-        "# tag"
-      ]
-    },
-    {
-      "name": "tags, inline comment, no whitespace control no padding",
-      "template": "{%# some comment %}",
-      "result": "",
-      "tags": [
-        "# tag"
-      ]
-    },
-    {
-      "name": "tags, inline comment, no padding after the hash",
-      "template": "{%#some comment %}",
-      "result": "",
-      "tags": [
-        "# tag"
-      ]
-    },
-    {
-      "name": "tags, inline comment, empty",
-      "template": "{%#%}",
-      "result": "",
-      "tags": [
-        "# tag"
-      ]
-    },
-    {
-      "name": "tags, inline comment, liquid tag",
-      "template": "{% liquid \n  # first comment line\n  # second comment line\n\n  # another comment line\n  echo 'Hello '\n\n  # more comments\n  echo 'goodbye'\n-%}",
-      "result": "Hello goodbye",
-      "tags": [
-        "# tag",
-        "echo tag",
-        "liquid tag"
-      ]
-    },
-    {
-      "name": "tags, inline comment, multiple lines",
-      "template": "{%-\n  # spread inline comments\n  # over multiple lines\n-%}",
-      "result": "",
-      "tags": [
-        "# tag"
-      ]
-    },
-    {
-      "name": "tags, inline comment, lots of hashes in a liquid tag",
-      "template": "{% liquid\n  ##########################\n  # spread inline comments #\n  ##########################\n-%}",
-      "result": "",
-      "tags": [
-        "# tag",
-        "liquid tag"
-      ]
-    },
-    {
-      "name": "tags, inline comment, enforce leading hash",
-      "template": "{%-\n  # spread inline comments\n  over multiple lines\n-%}",
-      "invalid": true,
-      "tags": [
-        "# tag"
-      ]
-    },
-    {
       "name": "tags, inline comment, can't comment tags",
       "template": "{%- # {% echo 'hello world' %} -%}",
       "result": " -%}",
-      "tags": [
-        "# tag"
-      ]
-    },
-    {
-      "name": "tags, inline comment, comment with single quote",
-      "template": "{%# some 'comment %}",
-      "result": "",
-      "tags": [
-        "# tag"
-      ]
-    },
-    {
-      "name": "tags, inline comment, comment with single quoted string",
-      "template": "{%# some 'comment' %}",
-      "result": "",
       "tags": [
         "# tag"
       ]
@@ -10249,6 +10150,22 @@
     {
       "name": "tags, inline comment, comment with double quoted string",
       "template": "{%# some \"comment\" %}",
+      "result": "",
+      "tags": [
+        "# tag"
+      ]
+    },
+    {
+      "name": "tags, inline comment, comment with single quote",
+      "template": "{%# some 'comment %}",
+      "result": "",
+      "tags": [
+        "# tag"
+      ]
+    },
+    {
+      "name": "tags, inline comment, comment with single quoted string",
+      "template": "{%# some 'comment' %}",
       "result": "",
       "tags": [
         "# tag"
@@ -10271,20 +10188,104 @@
       ]
     },
     {
-      "name": "tags, liquid, newline terminated tags",
-      "template": "{% liquid\nif product.title\n   echo product.title | upcase\nelse\n   echo 'product-1' | upcase \nendif\n\nfor i in (0..5)\n   echo i\nendfor %}",
-      "data": {
-        "product": {
-          "title": "foo"
-        }
-      },
-      "result": "FOO012345",
+      "name": "tags, inline comment, empty",
+      "template": "{%#%}",
+      "result": "",
+      "tags": [
+        "# tag"
+      ]
+    },
+    {
+      "name": "tags, inline comment, enforce leading hash",
+      "template": "{%-\n  # spread inline comments\n  over multiple lines\n-%}",
+      "invalid": true,
+      "tags": [
+        "# tag"
+      ]
+    },
+    {
+      "name": "tags, inline comment, liquid tag",
+      "template": "{% liquid \n  # first comment line\n  # second comment line\n\n  # another comment line\n  echo 'Hello '\n\n  # more comments\n  echo 'goodbye'\n-%}",
+      "result": "Hello goodbye",
+      "tags": [
+        "# tag",
+        "echo tag",
+        "liquid tag"
+      ]
+    },
+    {
+      "name": "tags, inline comment, lots of hashes in a liquid tag",
+      "template": "{% liquid\n  ##########################\n  # spread inline comments #\n  ##########################\n-%}",
+      "result": "",
+      "tags": [
+        "# tag",
+        "liquid tag"
+      ]
+    },
+    {
+      "name": "tags, inline comment, multiple lines",
+      "template": "{%-\n  # spread inline comments\n  # over multiple lines\n-%}",
+      "result": "",
+      "tags": [
+        "# tag"
+      ]
+    },
+    {
+      "name": "tags, inline comment, no padding after the hash",
+      "template": "{%#some comment %}",
+      "result": "",
+      "tags": [
+        "# tag"
+      ]
+    },
+    {
+      "name": "tags, inline comment, no whitespace control no padding",
+      "template": "{%# some comment %}",
+      "result": "",
+      "tags": [
+        "# tag"
+      ]
+    },
+    {
+      "name": "tags, inline comment, no whitespace control with padding",
+      "template": "{% # some comment %}",
+      "result": "",
+      "tags": [
+        "# tag"
+      ]
+    },
+    {
+      "name": "tags, inline comment, with whitespace control and padding",
+      "template": "{%- # some comment -%}",
+      "result": "",
+      "tags": [
+        "# tag"
+      ]
+    },
+    {
+      "name": "tags, inline comment, with whitespace control no padding",
+      "template": "{%-# some comment -%}",
+      "result": "",
+      "tags": [
+        "# tag"
+      ]
+    },
+    {
+      "name": "tags, liquid, bare liquid tag in liquid tag",
+      "template": "{%- liquid\n  liquid\n  echo \"foo\"\n-%}",
+      "result": "foo",
       "tags": [
         "echo tag",
-        "for tag",
+        "liquid tag"
+      ]
+    },
+    {
+      "name": "tags, liquid, can't close nested blocks",
+      "template": "{%- if true -%}\n42\n{%- liquid endif -%}",
+      "invalid": true,
+      "tags": [
         "if tag",
-        "liquid tag",
-        "upcase filter"
+        "liquid tag"
       ]
     },
     {
@@ -10330,19 +10331,11 @@
       ]
     },
     {
-      "name": "tags, liquid, only whitespace",
-      "template": "{% liquid\n   \n\n   \t \n\t\n  %}",
-      "result": "",
+      "name": "tags, liquid, liquid tag in liquid tag",
+      "template": "{%- liquid\n  liquid echo 'bar'\n  echo \"foo\"\n-%}",
+      "result": "barfoo",
       "tags": [
-        "liquid tag"
-      ]
-    },
-    {
-      "name": "tags, liquid, single line comment tag",
-      "template": "{% liquid\ncomment this is a comment\nendcomment\n%}",
-      "result": "",
-      "tags": [
-        "comment tag",
+        "echo tag",
         "liquid tag"
       ]
     },
@@ -10356,11 +10349,46 @@
       ]
     },
     {
-      "name": "tags, liquid, whitespace control",
-      "template": "Hello,     \n{%- liquid\n  echo ' World! '\n-%}\n   Goodbye.",
-      "result": "Hello, World! Goodbye.",
+      "name": "tags, liquid, nested liquid",
+      "template": "{%- if true %}\n  {%- liquid\n    echo \"good\"\n  %}\n{%- endif -%}",
+      "result": "good",
       "tags": [
         "echo tag",
+        "if tag",
+        "liquid tag"
+      ]
+    },
+    {
+      "name": "tags, liquid, nested liquid in liquid tag",
+      "template": "{%- liquid liquid liquid echo \"foo\" -%}",
+      "result": "foo",
+      "tags": [
+        "echo tag",
+        "liquid tag"
+      ]
+    },
+    {
+      "name": "tags, liquid, newline terminated tags",
+      "template": "{% liquid\nif product.title\n   echo product.title | upcase\nelse\n   echo 'product-1' | upcase \nendif\n\nfor i in (0..5)\n   echo i\nendfor %}",
+      "data": {
+        "product": {
+          "title": "foo"
+        }
+      },
+      "result": "FOO012345",
+      "tags": [
+        "echo tag",
+        "for tag",
+        "if tag",
+        "liquid tag",
+        "upcase filter"
+      ]
+    },
+    {
+      "name": "tags, liquid, only whitespace",
+      "template": "{% liquid\n   \n\n   \t \n\t\n  %}",
+      "result": "",
+      "tags": [
         "liquid tag"
       ]
     },
@@ -10412,50 +10440,27 @@
       ]
     },
     {
-      "name": "tags, liquid, nested liquid",
-      "template": "{%- if true %}\n  {%- liquid\n    echo \"good\"\n  %}\n{%- endif -%}",
-      "result": "good",
+      "name": "tags, liquid, single line comment tag",
+      "template": "{% liquid\ncomment this is a comment\nendcomment\n%}",
+      "result": "",
       "tags": [
-        "echo tag",
-        "if tag",
+        "comment tag",
         "liquid tag"
       ]
     },
     {
-      "name": "tags, liquid, can't close nested blocks",
-      "template": "{%- if true -%}\n42\n{%- liquid endif -%}",
-      "invalid": true,
-      "tags": [
-        "if tag",
-        "liquid tag"
-      ]
-    },
-    {
-      "name": "tags, liquid, bare liquid tag in liquid tag",
-      "template": "{%- liquid\n  liquid\n  echo \"foo\"\n-%}",
-      "result": "foo",
+      "name": "tags, liquid, whitespace control",
+      "template": "Hello,     \n{%- liquid\n  echo ' World! '\n-%}\n   Goodbye.",
+      "result": "Hello, World! Goodbye.",
       "tags": [
         "echo tag",
         "liquid tag"
       ]
     },
     {
-      "name": "tags, liquid, liquid tag in liquid tag",
-      "template": "{%- liquid\n  liquid echo 'bar'\n  echo \"foo\"\n-%}",
-      "result": "barfoo",
-      "tags": [
-        "echo tag",
-        "liquid tag"
-      ]
-    },
-    {
-      "name": "tags, liquid, nested liquid in liquid tag",
-      "template": "{%- liquid liquid liquid echo \"foo\" -%}",
-      "result": "foo",
-      "tags": [
-        "echo tag",
-        "liquid tag"
-      ]
+      "name": "tags, raw, continue after raw",
+      "template": "{% raw %} {% some raw content %} {% endraw %}a literal",
+      "result": " {% some raw content %} a literal"
     },
     {
       "name": "tags, raw, literal",
@@ -10468,36 +10473,61 @@
       "result": "{{ foo }}"
     },
     {
-      "name": "tags, raw, tag",
-      "template": "{% raw %}{% assign x = 1 %}{% endraw %}",
-      "result": "{% assign x = 1 %}"
-    },
-    {
       "name": "tags, raw, partial tag",
       "template": "{% raw %} %} {% }} {{ {% endraw %}",
       "result": " %} {% }} {{ "
     },
     {
-      "name": "tags, raw, continue after raw",
-      "template": "{% raw %} {% some raw content %} {% endraw %}a literal",
-      "result": " {% some raw content %} a literal"
+      "name": "tags, raw, tag",
+      "template": "{% raw %}{% assign x = 1 %}{% endraw %}",
+      "result": "{% assign x = 1 %}"
     },
     {
-      "name": "tags, render, string literal name",
-      "template": "{% render 'product-hero', product: product %}",
+      "name": "tags, render, assign to keyword argument",
+      "template": "{% render 'product-args', foo: 'hello' %}{{ foo }}",
+      "templates": {
+        "product-args": "{{ foo }}{% assign foo='goodbye' %} {{ foo }}"
+      },
+      "result": "hello goodbye",
+      "tags": [
+        "render tag"
+      ]
+    },
+    {
+      "name": "tags, render, assigned variables do not leak into outer scope",
+      "template": "{% render 'assign-outer-scope', customer: customer %} {{ last_name }}",
       "data": {
-        "product": {
-          "title": "foo",
-          "tags": [
-            "sports",
-            "garden"
+        "customer": {
+          "first_name": "Holly"
+        }
+      },
+      "templates": {
+        "assign-outer-scope": "Hello, {{ customer.first_name }}{% assign last_name = 'Smith' %}"
+      },
+      "result": "Hello, Holly ",
+      "tags": [
+        "render tag"
+      ]
+    },
+    {
+      "name": "tags, render, bound array variable",
+      "template": "{% render 'prod' for collection.products %}",
+      "data": {
+        "collection": {
+          "products": [
+            {
+              "title": "bike"
+            },
+            {
+              "title": "car"
+            }
           ]
         }
       },
       "templates": {
-        "product-hero": "{{ product.title }}\n{% for tag in product.tags %}- {{ tag }} {% endfor %}"
+        "prod": "{{ prod.title }}"
       },
-      "result": "foo\n- sports - garden ",
+      "result": "bikecar",
       "tags": [
         "render tag"
       ]
@@ -10537,29 +10567,6 @@
       ]
     },
     {
-      "name": "tags, render, bound array variable",
-      "template": "{% render 'prod' for collection.products %}",
-      "data": {
-        "collection": {
-          "products": [
-            {
-              "title": "bike"
-            },
-            {
-              "title": "car"
-            }
-          ]
-        }
-      },
-      "templates": {
-        "prod": "{{ prod.title }}"
-      },
-      "result": "bikecar",
-      "tags": [
-        "render tag"
-      ]
-    },
-    {
       "name": "tags, render, bound variable with alias",
       "template": "{% render 'product-alias' with collection.products[1] as product %}",
       "data": {
@@ -10578,6 +10585,124 @@
         "product-alias": "{{ product.title }}"
       },
       "result": "car",
+      "tags": [
+        "render tag"
+      ]
+    },
+    {
+      "name": "tags, render, decrement is isolated between renders",
+      "template": "{% decrement foo %} {% render 'decrement' %} {% decrement foo %}",
+      "templates": {
+        "decrement": "{% decrement foo %}"
+      },
+      "result": "-1 -1 -2",
+      "tags": [
+        "decrement tag",
+        "render tag"
+      ]
+    },
+    {
+      "name": "tags, render, for loop variables go out of scope",
+      "template": "{% for i in (1..3) %}{{ i }}{% render 'loop-scope' %}{{ i }}{% endfor %}{{ i }}",
+      "templates": {
+        "loop-scope": "{{ i }}"
+      },
+      "result": "112233",
+      "tags": [
+        "for tag",
+        "render tag"
+      ]
+    },
+    {
+      "name": "tags, render, forloop helper",
+      "template": "{% render 'product' for collection.products %}",
+      "data": {
+        "collection": {
+          "products": [
+            {
+              "title": "bike"
+            },
+            {
+              "title": "car"
+            }
+          ]
+        }
+      },
+      "templates": {
+        "product": "Product: {{ product.title }} {% if forloop.first %}first{% endif %}{% if forloop.last %}last{% endif %} index:{{ forloop.index }} "
+      },
+      "result": "Product: bike first index:1 Product: car last index:2 ",
+      "tags": [
+        "render tag"
+      ]
+    },
+    {
+      "name": "tags, render, increment is isolated between renders",
+      "template": "{% increment foo %} {% render 'increment' %} {% increment foo %}",
+      "templates": {
+        "increment": "{% increment foo %}"
+      },
+      "result": "0 0 1",
+      "tags": [
+        "increment tag",
+        "render tag"
+      ]
+    },
+    {
+      "name": "tags, render, parent variables go out of scope",
+      "template": "{% assign greeting = 'good morning' %}{{ greeting }} {% render 'outer-scope' %}{{ greeting }}",
+      "templates": {
+        "outer-scope": "{{ greeting }}"
+      },
+      "result": "good morning good morning",
+      "tags": [
+        "assign tag",
+        "render tag"
+      ]
+    },
+    {
+      "name": "tags, render, render loops can't access parentloop",
+      "template": "{% for x in (1..3) %}{% render 'product' for collection.products %}{% endfor %}",
+      "data": {
+        "collection": {
+          "products": [
+            {
+              "title": "bike"
+            },
+            {
+              "title": "car"
+            }
+          ]
+        }
+      },
+      "templates": {
+        "product": "{{ product.title }}-{{ forloop.index0 }} {{ forloop.parentloop.index0 }}"
+      },
+      "result": "bike-0 car-1 bike-0 car-1 bike-0 car-1 ",
+      "tags": [
+        "for tag",
+        "render tag"
+      ]
+    },
+    {
+      "name": "tags, render, render loops don't add parentloop",
+      "template": "{% render 'product' for collection.products %}",
+      "data": {
+        "collection": {
+          "products": [
+            {
+              "title": "bike"
+            },
+            {
+              "title": "car"
+            }
+          ]
+        }
+      },
+      "templates": {
+        "product": "{{ product.title }}-{{ forloop.index0 }} {% for x in (1..3) %}{{ forloop.index0 }}{{ forloop.parentloop.index0 }} {% endfor %}"
+      },
+      "result": "bike-0 0 1 2 car-1 0 1 2 ",
       "tags": [
         "render tag"
       ]
@@ -10616,148 +10741,91 @@
       ]
     },
     {
-      "name": "tags, render, parent variables go out of scope",
-      "template": "{% assign greeting = 'good morning' %}{{ greeting }} {% render 'outer-scope' %}{{ greeting }}",
-      "templates": {
-        "outer-scope": "{{ greeting }}"
+      "name": "tags, render, string literal name",
+      "template": "{% render 'product-hero', product: product %}",
+      "data": {
+        "product": {
+          "title": "foo",
+          "tags": [
+            "sports",
+            "garden"
+          ]
+        }
       },
-      "result": "good morning good morning",
+      "templates": {
+        "product-hero": "{{ product.title }}\n{% for tag in product.tags %}- {{ tag }} {% endfor %}"
+      },
+      "result": "foo\n- sports - garden ",
       "tags": [
-        "assign tag",
         "render tag"
       ]
     },
     {
-      "name": "tags, render, for loop variables go out of scope",
-      "template": "{% for i in (1..3) %}{{ i }}{% render 'loop-scope' %}{{ i }}{% endfor %}{{ i }}",
-      "templates": {
-        "loop-scope": "{{ i }}"
-      },
-      "result": "112233",
+      "name": "tags, tablerow, break from a tablerow loop",
+      "template": "{% tablerow n in (1..3) cols:2 %}{{n}}{% break %}{{n}}{% endtablerow %}",
+      "result": "<tr class=\"row1\">\n<td class=\"col1\">1</td></tr>\n",
       "tags": [
+        "break tag",
+        "tablerow tag"
+      ]
+    },
+    {
+      "name": "tags, tablerow, break from a tablerow loop inside a for loop",
+      "template": "{% for i in (1..2) -%}\\n{% for j in (1..2) -%}\\n{% tablerow k in (1..3) %}{% break %}{% endtablerow -%}\\nloop j={{ j }}\\n{% endfor -%}\\nloop i={{ i }}\\n{% endfor -%}\\nafter loop\\n",
+      "result": "\\n\\n<tr class=\"row1\">\n<td class=\"col1\"></td></tr>\n\\nloop j=1\\n\\n<tr class=\"row1\">\n<td class=\"col1\"></td></tr>\n\\nloop j=2\\n\\nloop i=1\\n\\n\\n<tr class=\"row1\">\n<td class=\"col1\"></td></tr>\n\\nloop j=1\\n\\n<tr class=\"row1\">\n<td class=\"col1\"></td></tr>\n\\nloop j=2\\n\\nloop i=2\\n\\nafter loop\\n",
+      "tags": [
+        "break tag",
         "for tag",
-        "render tag"
+        "tablerow tag"
       ]
     },
     {
-      "name": "tags, render, assigned variables do not leak into outer scope",
-      "template": "{% render 'assign-outer-scope', customer: customer %} {{ last_name }}",
-      "data": {
-        "customer": {
-          "first_name": "Holly"
-        }
-      },
-      "templates": {
-        "assign-outer-scope": "Hello, {{ customer.first_name }}{% assign last_name = 'Smith' %}"
-      },
-      "result": "Hello, Holly ",
+      "name": "tags, tablerow, cols is a float",
+      "template": "{% tablerow i in (1..4) cols:2.6 %}{{ i }} {{ tablerowloop.col_first }}{% endtablerow %}",
+      "result": "<tr class=\"row1\">\n<td class=\"col1\">1 true</td><td class=\"col2\">2 false</td></tr>\n<tr class=\"row2\"><td class=\"col1\">3 true</td><td class=\"col2\">4 false</td></tr>\n",
       "tags": [
-        "render tag"
+        "tablerow tag"
       ]
     },
     {
-      "name": "tags, render, increment is isolated between renders",
-      "template": "{% increment foo %} {% render 'increment' %} {% increment foo %}",
-      "templates": {
-        "increment": "{% increment foo %}"
-      },
-      "result": "0 0 1",
+      "name": "tags, tablerow, cols is a string",
+      "template": "{% tablerow i in (1..4) cols:'2' %}{{ i }} {{ tablerowloop.col_first }}{% endtablerow %}",
+      "result": "<tr class=\"row1\">\n<td class=\"col1\">1 true</td><td class=\"col2\">2 false</td></tr>\n<tr class=\"row2\"><td class=\"col1\">3 true</td><td class=\"col2\">4 false</td></tr>\n",
       "tags": [
-        "increment tag",
-        "render tag"
+        "tablerow tag"
       ]
     },
     {
-      "name": "tags, render, decrement is isolated between renders",
-      "template": "{% decrement foo %} {% render 'decrement' %} {% decrement foo %}",
-      "templates": {
-        "decrement": "{% decrement foo %}"
-      },
-      "result": "-1 -1 -2",
+      "name": "tags, tablerow, continue from a tablerow loop",
+      "template": "{% tablerow n in (1..3) cols:2 %}{{n}}{% continue %}{{n}}{% endtablerow %}",
+      "result": "<tr class=\"row1\">\n<td class=\"col1\">1</td><td class=\"col2\">2</td></tr>\n<tr class=\"row2\"><td class=\"col1\">3</td></tr>\n",
       "tags": [
-        "decrement tag",
-        "render tag"
+        "continue tag",
+        "tablerow tag"
       ]
     },
     {
-      "name": "tags, render, forloop helper",
-      "template": "{% render 'product' for collection.products %}",
-      "data": {
-        "collection": {
-          "products": [
-            {
-              "title": "bike"
-            },
-            {
-              "title": "car"
-            }
-          ]
-        }
-      },
-      "templates": {
-        "product": "Product: {{ product.title }} {% if forloop.first %}first{% endif %}{% if forloop.last %}last{% endif %} index:{{ forloop.index }} "
-      },
-      "result": "Product: bike first index:1 Product: car last index:2 ",
+      "name": "tags, tablerow, limit is a string",
+      "template": "{% tablerow i in (1..4) limit:'2' %}{{ i }} {{ tablerowloop.col_first }}{% endtablerow %}",
+      "result": "<tr class=\"row1\">\n<td class=\"col1\">1 true</td><td class=\"col2\">2 false</td></tr>\n",
       "tags": [
-        "render tag"
+        "tablerow tag"
       ]
     },
     {
-      "name": "tags, render, render loops don't add parentloop",
-      "template": "{% render 'product' for collection.products %}",
-      "data": {
-        "collection": {
-          "products": [
-            {
-              "title": "bike"
-            },
-            {
-              "title": "car"
-            }
-          ]
-        }
-      },
-      "templates": {
-        "product": "{{ product.title }}-{{ forloop.index0 }} {% for x in (1..3) %}{{ forloop.index0 }}{{ forloop.parentloop.index0 }} {% endfor %}"
-      },
-      "result": "bike-0 0 1 2 car-1 0 1 2 ",
+      "name": "tags, tablerow, no cols param",
+      "template": "{% tablerow i in (1..2) %}\ncol: {{ tablerowloop.col }}\ncol0: {{ tablerowloop.col0 }}\ncol_first: {{ tablerowloop.col_first }}\ncol_last: {{ tablerowloop.col_last }}\nfirst: {{ tablerowloop.first }}\nindex: {{ tablerowloop.index }}\nindex0: {{ tablerowloop.index0 }}\nlast: {{ tablerowloop.last }}\nlength: {{ tablerowloop.length }}\nrindex: {{ tablerowloop.rindex }}\nrindex0: {{ tablerowloop.rindex0 }}\nrow: {{ tablerowloop.row }}\n{% endtablerow %}",
+      "result": "<tr class=\"row1\">\n<td class=\"col1\">\ncol: 1\ncol0: 0\ncol_first: true\ncol_last: false\nfirst: true\nindex: 1\nindex0: 0\nlast: false\nlength: 2\nrindex: 2\nrindex0: 1\nrow: 1\n</td><td class=\"col2\">\ncol: 2\ncol0: 1\ncol_first: false\ncol_last: true\nfirst: false\nindex: 2\nindex0: 1\nlast: true\nlength: 2\nrindex: 1\nrindex0: 0\nrow: 1\n</td></tr>\n",
       "tags": [
-        "render tag"
+        "tablerow tag"
       ]
     },
     {
-      "name": "tags, render, render loops can't access parentloop",
-      "template": "{% for x in (1..3) %}{% render 'product' for collection.products %}{% endfor %}",
-      "data": {
-        "collection": {
-          "products": [
-            {
-              "title": "bike"
-            },
-            {
-              "title": "car"
-            }
-          ]
-        }
-      },
-      "templates": {
-        "product": "{{ product.title }}-{{ forloop.index0 }} {{ forloop.parentloop.index0 }}"
-      },
-      "result": "bike-0 car-1 bike-0 car-1 bike-0 car-1 ",
+      "name": "tags, tablerow, offset is a string",
+      "template": "{% tablerow i in (1..4) offset:'2' %}{{ i }} {{ tablerowloop.col_first }}{% endtablerow %}",
+      "result": "<tr class=\"row1\">\n<td class=\"col1\">3 true</td><td class=\"col2\">4 false</td></tr>\n",
       "tags": [
-        "for tag",
-        "render tag"
-      ]
-    },
-    {
-      "name": "tags, render, assign to keyword argument",
-      "template": "{% render 'product-args', foo: 'hello' %}{{ foo }}",
-      "templates": {
-        "product-args": "{{ foo }}{% assign foo='goodbye' %} {{ foo }}"
-      },
-      "result": "hello goodbye",
-      "tags": [
-        "render tag"
+        "tablerow tag"
       ]
     },
     {
@@ -10815,6 +10883,30 @@
       ]
     },
     {
+      "name": "tags, tablerow, two column odd range",
+      "template": "{% tablerow i in (1..5) cols:2 %}{{ i }} {{ tablerowloop.col_first }}{% endtablerow %}",
+      "result": "<tr class=\"row1\">\n<td class=\"col1\">1 true</td><td class=\"col2\">2 false</td></tr>\n<tr class=\"row2\"><td class=\"col1\">3 true</td><td class=\"col2\">4 false</td></tr>\n<tr class=\"row3\"><td class=\"col1\">5 true</td></tr>\n",
+      "tags": [
+        "tablerow tag"
+      ]
+    },
+    {
+      "name": "tags, tablerow, two column odd range row numbers",
+      "template": "{% tablerow i in (1..5) cols:2 %}{{ i }} {{ tablerowloop.row }}{% endtablerow %}",
+      "result": "<tr class=\"row1\">\n<td class=\"col1\">1 1</td><td class=\"col2\">2 1</td></tr>\n<tr class=\"row2\"><td class=\"col1\">3 2</td><td class=\"col2\">4 2</td></tr>\n<tr class=\"row3\"><td class=\"col1\">5 3</td></tr>\n",
+      "tags": [
+        "tablerow tag"
+      ]
+    },
+    {
+      "name": "tags, tablerow, two column range",
+      "template": "{% tablerow i in (1..4) cols:2 %}{{ i }} {{ tablerowloop.col_first }}{% endtablerow %}",
+      "result": "<tr class=\"row1\">\n<td class=\"col1\">1 true</td><td class=\"col2\">2 false</td></tr>\n<tr class=\"row2\"><td class=\"col1\">3 true</td><td class=\"col2\">4 false</td></tr>\n",
+      "tags": [
+        "tablerow tag"
+      ]
+    },
+    {
       "name": "tags, tablerow, two columns",
       "template": "{% tablerow tag in collection.tags cols:2 %}{{ tag }}{% endtablerow %}",
       "data": {
@@ -10833,165 +10925,9 @@
       ]
     },
     {
-      "name": "tags, tablerow, two column range",
-      "template": "{% tablerow i in (1..4) cols:2 %}{{ i }} {{ tablerowloop.col_first }}{% endtablerow %}",
-      "result": "<tr class=\"row1\">\n<td class=\"col1\">1 true</td><td class=\"col2\">2 false</td></tr>\n<tr class=\"row2\"><td class=\"col1\">3 true</td><td class=\"col2\">4 false</td></tr>\n",
-      "tags": [
-        "tablerow tag"
-      ]
-    },
-    {
-      "name": "tags, tablerow, two column odd range",
-      "template": "{% tablerow i in (1..5) cols:2 %}{{ i }} {{ tablerowloop.col_first }}{% endtablerow %}",
-      "result": "<tr class=\"row1\">\n<td class=\"col1\">1 true</td><td class=\"col2\">2 false</td></tr>\n<tr class=\"row2\"><td class=\"col1\">3 true</td><td class=\"col2\">4 false</td></tr>\n<tr class=\"row3\"><td class=\"col1\">5 true</td></tr>\n",
-      "tags": [
-        "tablerow tag"
-      ]
-    },
-    {
-      "name": "tags, tablerow, two column odd range row numbers",
-      "template": "{% tablerow i in (1..5) cols:2 %}{{ i }} {{ tablerowloop.row }}{% endtablerow %}",
-      "result": "<tr class=\"row1\">\n<td class=\"col1\">1 1</td><td class=\"col2\">2 1</td></tr>\n<tr class=\"row2\"><td class=\"col1\">3 2</td><td class=\"col2\">4 2</td></tr>\n<tr class=\"row3\"><td class=\"col1\">5 3</td></tr>\n",
-      "tags": [
-        "tablerow tag"
-      ]
-    },
-    {
-      "name": "tags, tablerow, no cols param",
-      "template": "{% tablerow i in (1..2) %}\ncol: {{ tablerowloop.col }}\ncol0: {{ tablerowloop.col0 }}\ncol_first: {{ tablerowloop.col_first }}\ncol_last: {{ tablerowloop.col_last }}\nfirst: {{ tablerowloop.first }}\nindex: {{ tablerowloop.index }}\nindex0: {{ tablerowloop.index0 }}\nlast: {{ tablerowloop.last }}\nlength: {{ tablerowloop.length }}\nrindex: {{ tablerowloop.rindex }}\nrindex0: {{ tablerowloop.rindex0 }}\nrow: {{ tablerowloop.row }}\n{% endtablerow %}",
-      "result": "<tr class=\"row1\">\n<td class=\"col1\">\ncol: 1\ncol0: 0\ncol_first: true\ncol_last: false\nfirst: true\nindex: 1\nindex0: 0\nlast: false\nlength: 2\nrindex: 2\nrindex0: 1\nrow: 1\n</td><td class=\"col2\">\ncol: 2\ncol0: 1\ncol_first: false\ncol_last: true\nfirst: false\nindex: 2\nindex0: 1\nlast: true\nlength: 2\nrindex: 1\nrindex0: 0\nrow: 1\n</td></tr>\n",
-      "tags": [
-        "tablerow tag"
-      ]
-    },
-    {
-      "name": "tags, tablerow, cols is a string",
-      "template": "{% tablerow i in (1..4) cols:'2' %}{{ i }} {{ tablerowloop.col_first }}{% endtablerow %}",
-      "result": "<tr class=\"row1\">\n<td class=\"col1\">1 true</td><td class=\"col2\">2 false</td></tr>\n<tr class=\"row2\"><td class=\"col1\">3 true</td><td class=\"col2\">4 false</td></tr>\n",
-      "tags": [
-        "tablerow tag"
-      ]
-    },
-    {
-      "name": "tags, tablerow, cols is a float",
-      "template": "{% tablerow i in (1..4) cols:2.6 %}{{ i }} {{ tablerowloop.col_first }}{% endtablerow %}",
-      "result": "<tr class=\"row1\">\n<td class=\"col1\">1 true</td><td class=\"col2\">2 false</td></tr>\n<tr class=\"row2\"><td class=\"col1\">3 true</td><td class=\"col2\">4 false</td></tr>\n",
-      "tags": [
-        "tablerow tag"
-      ]
-    },
-    {
-      "name": "tags, tablerow, limit is a string",
-      "template": "{% tablerow i in (1..4) limit:'2' %}{{ i }} {{ tablerowloop.col_first }}{% endtablerow %}",
-      "result": "<tr class=\"row1\">\n<td class=\"col1\">1 true</td><td class=\"col2\">2 false</td></tr>\n",
-      "tags": [
-        "tablerow tag"
-      ]
-    },
-    {
-      "name": "tags, tablerow, offset is a string",
-      "template": "{% tablerow i in (1..4) offset:'2' %}{{ i }} {{ tablerowloop.col_first }}{% endtablerow %}",
-      "result": "<tr class=\"row1\">\n<td class=\"col1\">3 true</td><td class=\"col2\">4 false</td></tr>\n",
-      "tags": [
-        "tablerow tag"
-      ]
-    },
-    {
-      "name": "tags, tablerow, break from a tablerow loop",
-      "template": "{% tablerow n in (1..3) cols:2 %}{{n}}{% break %}{{n}}{% endtablerow %}",
-      "result": "<tr class=\"row1\">\n<td class=\"col1\">1</td></tr>\n",
-      "tags": [
-        "break tag",
-        "tablerow tag"
-      ]
-    },
-    {
-      "name": "tags, tablerow, continue from a tablerow loop",
-      "template": "{% tablerow n in (1..3) cols:2 %}{{n}}{% continue %}{{n}}{% endtablerow %}",
-      "result": "<tr class=\"row1\">\n<td class=\"col1\">1</td><td class=\"col2\">2</td></tr>\n<tr class=\"row2\"><td class=\"col1\">3</td></tr>\n",
-      "tags": [
-        "continue tag",
-        "tablerow tag"
-      ]
-    },
-    {
-      "name": "tags, tablerow, break from a tablerow loop inside a for loop",
-      "template": "{% for i in (1..2) -%}\\n{% for j in (1..2) -%}\\n{% tablerow k in (1..3) %}{% break %}{% endtablerow -%}\\nloop j={{ j }}\\n{% endfor -%}\\nloop i={{ i }}\\n{% endfor -%}\\nafter loop\\n",
-      "result": "\\n\\n<tr class=\"row1\">\n<td class=\"col1\"></td></tr>\n\\nloop j=1\\n\\n<tr class=\"row1\">\n<td class=\"col1\"></td></tr>\n\\nloop j=2\\n\\nloop i=1\\n\\n\\n<tr class=\"row1\">\n<td class=\"col1\"></td></tr>\n\\nloop j=1\\n\\n<tr class=\"row1\">\n<td class=\"col1\"></td></tr>\n\\nloop j=2\\n\\nloop i=2\\n\\nafter loop\\n",
-      "tags": [
-        "break tag",
-        "for tag",
-        "tablerow tag"
-      ]
-    },
-    {
-      "name": "tags, unless, literal false condition",
-      "template": "{% unless false %}foo{% endunless %}",
-      "result": "foo",
-      "tags": [
-        "unless tag"
-      ]
-    },
-    {
-      "name": "tags, unless, literal true condition",
-      "template": "{% unless true %}foo{% endunless %}",
-      "result": "",
-      "tags": [
-        "unless tag"
-      ]
-    },
-    {
-      "name": "tags, unless, blocks that contain only whitespace are not rendered",
-      "template": "{% unless false %}  {% endunless %}",
-      "result": "",
-      "tags": [
-        "unless tag"
-      ]
-    },
-    {
       "name": "tags, unless, alternative block",
       "template": "{% unless true %}foo{% else %}bar{% endunless %}",
       "result": "bar",
-      "tags": [
-        "unless tag"
-      ]
-    },
-    {
-      "name": "tags, unless, conditional alternative block",
-      "template": "{% unless true %}foo{% elsif true %}bar{% endunless %}",
-      "result": "bar",
-      "tags": [
-        "unless tag"
-      ]
-    },
-    {
-      "name": "tags, unless, conditional alternative block with default",
-      "template": "{% unless true %}foo{% elsif false %}bar{% else %}hello{% endunless %}",
-      "result": "hello",
-      "tags": [
-        "unless tag"
-      ]
-    },
-    {
-      "name": "tags, unless, zero is not equal to false",
-      "template": "{% unless 0 == false %}Hello{% else %}Goodbye{% endunless %}",
-      "result": "Hello",
-      "tags": [
-        "unless tag"
-      ]
-    },
-    {
-      "name": "tags, unless, zero is truthy",
-      "template": "{% unless 0 %}Hello{% else %}Goodbye{% endunless %}",
-      "result": "Goodbye",
-      "tags": [
-        "unless tag"
-      ]
-    },
-    {
-      "name": "tags, unless, one is not equal to true",
-      "template": "{% unless 1 == true %}Hello{% else %}Goodbye{% endunless %}",
-      "result": "Hello",
       "tags": [
         "unless tag"
       ]
@@ -11024,6 +10960,30 @@
       ]
     },
     {
+      "name": "tags, unless, blocks that contain only whitespace are not rendered",
+      "template": "{% unless false %}  {% endunless %}",
+      "result": "",
+      "tags": [
+        "unless tag"
+      ]
+    },
+    {
+      "name": "tags, unless, conditional alternative block",
+      "template": "{% unless true %}foo{% elsif true %}bar{% endunless %}",
+      "result": "bar",
+      "tags": [
+        "unless tag"
+      ]
+    },
+    {
+      "name": "tags, unless, conditional alternative block with default",
+      "template": "{% unless true %}foo{% elsif false %}bar{% else %}hello{% endunless %}",
+      "result": "hello",
+      "tags": [
+        "unless tag"
+      ]
+    },
+    {
       "name": "tags, unless, else tag expressions are ignored",
       "template": "{% unless true %}1{% else nonsense %}2{% endunless %}",
       "tags": [
@@ -11049,6 +11009,46 @@
         "unless tag"
       ],
       "result": "2"
+    },
+    {
+      "name": "tags, unless, literal false condition",
+      "template": "{% unless false %}foo{% endunless %}",
+      "result": "foo",
+      "tags": [
+        "unless tag"
+      ]
+    },
+    {
+      "name": "tags, unless, literal true condition",
+      "template": "{% unless true %}foo{% endunless %}",
+      "result": "",
+      "tags": [
+        "unless tag"
+      ]
+    },
+    {
+      "name": "tags, unless, one is not equal to true",
+      "template": "{% unless 1 == true %}Hello{% else %}Goodbye{% endunless %}",
+      "result": "Hello",
+      "tags": [
+        "unless tag"
+      ]
+    },
+    {
+      "name": "tags, unless, zero is not equal to false",
+      "template": "{% unless 0 == false %}Hello{% else %}Goodbye{% endunless %}",
+      "result": "Hello",
+      "tags": [
+        "unless tag"
+      ]
+    },
+    {
+      "name": "tags, unless, zero is truthy",
+      "template": "{% unless 0 %}Hello{% else %}Goodbye{% endunless %}",
+      "result": "Goodbye",
+      "tags": [
+        "unless tag"
+      ]
     }
   ]
 }

--- a/golden_liquid.schema.json
+++ b/golden_liquid.schema.json
@@ -103,6 +103,7 @@
     },
     "tags": {
       "type": "array",
+      "uniqueItems": true,
       "items": {
         "type": "string",
         "enum": [


### PR DESCRIPTION
This PR changes the build script to sort test cases by name and sort test tags lexicographically.

Also, for good measure, I've set `uniqueItems` to `true` for the `tags` object in `golden_liquid.schema.json`.

In summary, at build time:

- test files are sorted by file name, with files being visited before subfolders.
- each file's `tests` array is sorted by the test's `name` key.
- each test's `tags` array is sorted alphabetically.

Ordering of `tests` and `tags` is not enforced for test suite source files found in the `./tests` directory, but both `tests` and `tags` are checked for uniqueness in all files.

And I've deliberately stopped short of sorting `test_case` object keys, for now.