### PR TITLE
Add tests for looping over empty strings and non iterable objects

### DIFF
--- a/golden_liquid.json
+++ b/golden_liquid.json
@@ -8727,6 +8727,17 @@
       ]
     },
     {
+      "name": "tags, for, loop over a non-iterable object",
+      "template": "{% for i in x %}{{ i }} {% endfor %}",
+      "data": {
+        "x": true
+      },
+      "result": "",
+      "tags": [
+        "for tag"
+      ]
+    },
+    {
       "name": "tags, for, loop over a string literal",
       "template": "{% for i in 'hello' %}{{ i }} {% endfor %}",
       "result": "hello ",
@@ -8757,6 +8768,14 @@
         }
       },
       "result": "garden sports ",
+      "tags": [
+        "for tag"
+      ]
+    },
+    {
+      "name": "tags, for, loop over an empty string",
+      "template": "{% for i in '' %}{{ i }} {% endfor %}",
+      "result": "",
       "tags": [
         "for tag"
       ]

--- a/tests/tags/for.json
+++ b/tests/tags/for.json
@@ -859,12 +859,31 @@
       ]
     },
     {
+      "name": "loop over an empty string",
+      "template": "{% for i in '' %}{{ i }} {% endfor %}",
+      "result": "",
+      "tags": [
+        "for tag"
+      ]
+    },
+    {
       "name": "loop over a string variable",
       "template": "{% for i in foo %}{{ i }} {% endfor %}",
       "data": {
         "foo": "hello"
       },
       "result": "hello ",
+      "tags": [
+        "for tag"
+      ]
+    },
+    {
+      "name": "loop over a non-iterable object",
+      "template": "{% for i in x %}{{ i }} {% endfor %}",
+      "data": {
+        "x": true
+      },
+      "result": "",
       "tags": [
         "for tag"
       ]


### PR DESCRIPTION
Add tests for looping over empty strings and non iterable objects with the `{% for %}` tag.

When iterating over a string with the `{% for %}` tag, the string is implicitly wrapped in a single element array, unless the string is empty, in which case the loop is a no-op.

Otherwise, if the target of a `{% for %}` loop is not iterable, the loop is a no-op, not an error condition.