### PR TITLE
Add more `blank` and `empty` test cases

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/Shopify/liquid.git
-  revision: a9c85622ddd784078c2eed34b19a351fe57362cf
+  revision: 6d81b1b68cf576cc9643ada149c7aa06c25304b8
   branch: main
   specs:
     liquid (5.12.0)

--- a/golden_liquid.json
+++ b/golden_liquid.json
@@ -2,6 +2,28 @@
   "description": "Golden Liquid test suite",
   "tests": [
     {
+      "name": "blank and empty, alias blank",
+      "template": "{% assign x = blank %}{% if '' == x %}TRUE{% else %}FALSE{% endif %}",
+      "data": {},
+      "result": "TRUE",
+      "tags": [
+        "assign tag",
+        "blank",
+        "if tag"
+      ]
+    },
+    {
+      "name": "blank and empty, alias empty",
+      "template": "{% assign x = empty %}{% if '' == x %}TRUE{% else %}FALSE{% endif %}",
+      "data": {},
+      "result": "TRUE",
+      "tags": [
+        "assign tag",
+        "empty",
+        "if tag"
+      ]
+    },
+    {
       "name": "blank and empty, array of length 0 is equal to blank",
       "template": "{% if a == blank %}TRUE{% else %}FALSE{% endif %}",
       "data": {
@@ -211,6 +233,27 @@
       "tags": [
         "empty",
         "if tag"
+      ]
+    },
+    {
+      "name": "blank and empty, loop over blank",
+      "template": "{% for x in blank %}{% endfor %}",
+      "data": {},
+      "result": "",
+      "tags": [
+        "blank",
+        "for tag",
+        "if tag"
+      ]
+    },
+    {
+      "name": "blank and empty, loop over empty",
+      "template": "{% for x in blank %}{{ x }}{% endfor %}",
+      "data": {},
+      "result": "",
+      "tags": [
+        "empty",
+        "for tag"
       ]
     },
     {

--- a/tests/blank_and_empty.json
+++ b/tests/blank_and_empty.json
@@ -255,6 +255,34 @@
       "data": {},
       "result": "1",
       "tags": ["empty"]
+    },
+    {
+      "name": "loop over blank",
+      "template": "{% for x in blank %}{% endfor %}",
+      "data": {},
+      "result": "",
+      "tags": ["blank", "for tag"]
+    },
+    {
+      "name": "loop over empty",
+      "template": "{% for x in blank %}{{ x }}{% endfor %}",
+      "data": {},
+      "result": "",
+      "tags": ["empty", "for tag"]
+    },
+    {
+      "name": "alias blank",
+      "template": "{% assign x = blank %}{% if '' == x %}TRUE{% else %}FALSE{% endif %}",
+      "data": {},
+      "result": "TRUE",
+      "tags": ["blank", "assign tag", "if tag"]
+    },
+    {
+      "name": "alias empty",
+      "template": "{% assign x = empty %}{% if '' == x %}TRUE{% else %}FALSE{% endif %}",
+      "data": {},
+      "result": "TRUE",
+      "tags": ["empty", "assign tag", "if tag"]
     }
   ]
 }


### PR DESCRIPTION
Test that:

- `blank` and `empty` are coerced to an empty array when used as the target in a `for` loop.
- `blank` and `empty` can be aliased with `assign`. 