### PR TITLE
Tidy `{% comment %}` tag test cases

### DIFF
--- a/golden_liquid.json
+++ b/golden_liquid.json
@@ -8183,6 +8183,22 @@
       ]
     },
     {
+      "name": "tags, comment, closing output delimiters are not parsed",
+      "template": "{% comment %} }} }} {%- endcomment %}",
+      "result": "",
+      "tags": [
+        "comment tag"
+      ]
+    },
+    {
+      "name": "tags, comment, closing tag delimiters are not parsed",
+      "template": "{% comment %} %} %}{% endcomment %}",
+      "result": "",
+      "tags": [
+        "comment tag"
+      ]
+    },
+    {
       "name": "tags, comment, comment inside liquid tag",
       "template": "{% liquid\n    if 1 != 1\n    comment\n    else\n    echo 123\n    endcomment\n    endif\n%}",
       "result": "",
@@ -8190,14 +8206,6 @@
         "comment tag",
         "if tag",
         "liquid tag"
-      ]
-    },
-    {
-      "name": "tags, comment, commented tags are not parsed",
-      "template": "{% comment %}    {% if true %}    {% if ... %}    {%- for ? -%}    {% while true %}    {%    unless if    %}    {% endcase %}{% endcomment %}",
-      "result": "",
-      "tags": [
-        "comment tag"
       ]
     },
     {
@@ -8209,7 +8217,7 @@
       ]
     },
     {
-      "name": "tags, comment, don't render comments with tags",
+      "name": "tags, comment, don't render comments with nested tags",
       "template": "{% comment %}{% if true %}{{ title }}{% endif %}{% endcomment %}",
       "result": "",
       "tags": [
@@ -8217,15 +8225,31 @@
       ]
     },
     {
-      "name": "tags, comment, incomplete tags are not parsed",
-      "template": "{% comment %}{% {{ {%- endcomment %}",
+      "name": "tags, comment, fully formed nested output markup is not parsed",
+      "template": "{% comment %}{{ ! }}  {% endcomment %}",
+      "result": "",
+      "tags": [
+        "comment tag"
+      ]
+    },
+    {
+      "name": "tags, comment, fully formed nested tags are not parsed",
+      "template": "{% comment %}    {% if true %}    {% if ... %}    {%- for ? -%}    {% while true %}    {%    unless if    %}    {% endcase %}{% endcomment %}",
+      "result": "",
+      "tags": [
+        "comment tag"
+      ]
+    },
+    {
+      "name": "tags, comment, incomplete nested output markup is a syntax error",
+      "template": "{% comment %}{{ {%- endcomment %}",
       "invalid": true,
       "tags": [
         "comment tag"
       ]
     },
     {
-      "name": "tags, comment, malformed tags are not parsed",
+      "name": "tags, comment, incomplete nested tags are a syntax error",
       "template": "{% comment %}{% assign foo = '1'{% endcomment %}",
       "invalid": true,
       "tags": [
@@ -8249,7 +8273,7 @@
       ]
     },
     {
-      "name": "tags, comment, raw inside comment block",
+      "name": "tags, comment, nested raw block",
       "template": "{% comment %}    {% raw %}    {% endcomment %}    {% endraw %}{% endcomment %}",
       "result": "",
       "tags": [
@@ -8265,8 +8289,16 @@
       ]
     },
     {
-      "name": "tags, comment, unclosed nested comment blocks",
+      "name": "tags, comment, unbalanced nested comment blocks",
       "template": "{% comment %}    {% comment %}    {% comment %}    {% endcomment %}{% endcomment %}",
+      "invalid": true,
+      "tags": [
+        "comment tag"
+      ]
+    },
+    {
+      "name": "tags, comment, unbalanced nested raw tag",
+      "template": "{% comment %}    {% raw %} ! {% endcomment %}",
       "invalid": true,
       "tags": [
         "comment tag"

--- a/tests/tags/comment.json
+++ b/tests/tags/comment.json
@@ -17,7 +17,7 @@
       ]
     },
     {
-      "name": "don't render comments with tags",
+      "name": "don't render comments with nested tags",
       "template": "{% comment %}{% if true %}{{ title }}{% endif %}{% endcomment %}",
       "result": "",
       "tags": [
@@ -35,7 +35,7 @@
       ]
     },
     {
-      "name": "commented tags are not parsed",
+      "name": "fully formed nested tags are not parsed",
       "template": "{% comment %}    {% if true %}    {% if ... %}    {%- for ? -%}    {% while true %}    {%    unless if    %}    {% endcase %}{% endcomment %}",
       "result": "",
       "tags": [
@@ -43,7 +43,15 @@
       ]
     },
     {
-      "name": "malformed tags are not parsed",
+      "name": "fully formed nested output markup is not parsed",
+      "template": "{% comment %}{{ ! }}  {% endcomment %}",
+      "result": "",
+      "tags": [
+        "comment tag"
+      ]
+    },
+    {
+      "name": "incomplete nested tags are a syntax error",
       "template": "{% comment %}{% assign foo = '1'{% endcomment %}",
       "invalid": true,
       "tags": [
@@ -51,9 +59,25 @@
       ]
     },
     {
-      "name": "incomplete tags are not parsed",
-      "template": "{% comment %}{% {{ {%- endcomment %}",
+      "name": "incomplete nested output markup is a syntax error",
+      "template": "{% comment %}{{ {%- endcomment %}",
       "invalid": true,
+      "tags": [
+        "comment tag"
+      ]
+    },
+    {
+      "name": "closing tag delimiters are not parsed",
+      "template": "{% comment %} %} %}{% endcomment %}",
+      "result": "",
+      "tags": [
+        "comment tag"
+      ]
+    },
+    {
+      "name": "closing output delimiters are not parsed",
+      "template": "{% comment %} }} }} {%- endcomment %}",
+      "result": "",
       "tags": [
         "comment tag"
       ]
@@ -75,7 +99,7 @@
       ]
     },
     {
-      "name": "unclosed nested comment blocks",
+      "name": "unbalanced nested comment blocks",
       "template": "{% comment %}    {% comment %}    {% comment %}    {% endcomment %}{% endcomment %}",
       "invalid": true,
       "tags": [
@@ -83,9 +107,17 @@
       ]
     },
     {
-      "name": "raw inside comment block",
+      "name": "nested raw block",
       "template": "{% comment %}    {% raw %}    {% endcomment %}    {% endraw %}{% endcomment %}",
       "result": "",
+      "tags": [
+        "comment tag"
+      ]
+    },
+    {
+      "name": "unbalanced nested raw tag",
+      "template": "{% comment %}    {% raw %} ! {% endcomment %}",
+      "invalid": true,
       "tags": [
         "comment tag"
       ]


### PR DESCRIPTION
This PR fixes test case names and adds tests cases to `tests/tags/comment.json`, improving coverage of incomplete and malformed markup within `{% comment %}` blocks.