### PR TITLE
Test the `squish` filter

### DIFF
--- a/golden_liquid.json
+++ b/golden_liquid.json
@@ -6630,6 +6630,134 @@
       ]
     },
     {
+      "name": "filters, squish, any whitespace before between and after",
+      "template": "{{ \" \n\t\r\nHello  \n\t\r\n \n\t\r\n World!  \n\t\r\n\" | squish }}",
+      "result": "Hello World!",
+      "tags": [
+        "squish filter"
+      ]
+    },
+    {
+      "name": "filters, squish, empty string",
+      "template": "{{ \"\" | squish }}",
+      "result": "",
+      "tags": [
+        "squish filter"
+      ]
+    },
+    {
+      "name": "filters, squish, just space after",
+      "template": "{{ \"HelloWorld!  \" | squish }}",
+      "result": "HelloWorld!",
+      "tags": [
+        "squish filter"
+      ]
+    },
+    {
+      "name": "filters, squish, just space before",
+      "template": "{{ \" HelloWorld!\" | squish }}",
+      "result": "HelloWorld!",
+      "tags": [
+        "squish filter"
+      ]
+    },
+    {
+      "name": "filters, squish, just space between",
+      "template": "{{ \"Hello   World!\" | squish }}",
+      "result": "Hello World!",
+      "tags": [
+        "squish filter"
+      ]
+    },
+    {
+      "name": "filters, squish, just whitespace",
+      "template": "{{ \" \n\t\r\" | squish }}",
+      "result": "",
+      "tags": [
+        "squish filter"
+      ]
+    },
+    {
+      "name": "filters, squish, left is a float",
+      "template": "{{ 5.2 | squish }}",
+      "result": "5.2",
+      "tags": [
+        "squish filter"
+      ]
+    },
+    {
+      "name": "filters, squish, left is an integer",
+      "template": "{{ 5 | squish }}",
+      "result": "5",
+      "tags": [
+        "squish filter"
+      ]
+    },
+    {
+      "name": "filters, squish, left is false",
+      "template": "{{ false | squish }}",
+      "result": "false",
+      "tags": [
+        "squish filter"
+      ]
+    },
+    {
+      "name": "filters, squish, left is nil",
+      "template": "{{ nil | squish }}",
+      "result": "",
+      "tags": [
+        "squish filter"
+      ]
+    },
+    {
+      "name": "filters, squish, left is null",
+      "template": "{{ null | squish }}",
+      "result": "",
+      "tags": [
+        "squish filter"
+      ]
+    },
+    {
+      "name": "filters, squish, left is true",
+      "template": "{{ true | squish }}",
+      "result": "true",
+      "tags": [
+        "squish filter"
+      ]
+    },
+    {
+      "name": "filters, squish, line terminators collapse to a single space",
+      "template": "{{ \"Hello\n\t\r\nthere\n\t\r\nWorld!\" | squish }}",
+      "result": "Hello there World!",
+      "tags": [
+        "squish filter"
+      ]
+    },
+    {
+      "name": "filters, squish, many words",
+      "template": "{{ \" \n\t\r\nHello  \n\t\r\nthere \n\t\r\nWorld!  \n\t\r\n\" | squish }}",
+      "result": "Hello there World!",
+      "tags": [
+        "squish filter"
+      ]
+    },
+    {
+      "name": "filters, squish, space before and after",
+      "template": "{{ \" HelloWorld!   \" | squish }}",
+      "result": "HelloWorld!",
+      "tags": [
+        "squish filter"
+      ]
+    },
+    {
+      "name": "filters, squish, space before between and after",
+      "template": "{{ \" Hello    World!   \" | squish }}",
+      "result": "Hello World!",
+      "tags": [
+        "squish filter"
+      ]
+    },
+    {
       "name": "filters, strip, left and right padded",
       "template": "{{ \" \t\r\n  hello  \t\r\n \" | strip }}",
       "result": "hello",

--- a/golden_liquid.schema.json
+++ b/golden_liquid.schema.json
@@ -182,6 +182,7 @@
           "strip filter",
           "strip_html filter",
           "strip_newlines filter",
+          "squish filter",
           "sum filter",
           "tablerow tag",
           "times filter",

--- a/tests/filters/squish.json
+++ b/tests/filters/squish.json
@@ -1,0 +1,106 @@
+{
+  "tests": [
+    {
+      "name": "empty string",
+      "template": "{{ \"\" | squish }}",
+      "result": "",
+      "tags": ["squish filter"]
+    },
+    {
+      "name": "space before between and after",
+      "template": "{{ \" Hello    World!   \" | squish }}",
+      "result": "Hello World!",
+      "tags": ["squish filter"]
+    },
+    {
+      "name": "space before and after",
+      "template": "{{ \" HelloWorld!   \" | squish }}",
+      "result": "HelloWorld!",
+      "tags": ["squish filter"]
+    },
+    {
+      "name": "just space before",
+      "template": "{{ \" HelloWorld!\" | squish }}",
+      "result": "HelloWorld!",
+      "tags": ["squish filter"]
+    },
+    {
+      "name": "just space after",
+      "template": "{{ \"HelloWorld!  \" | squish }}",
+      "result": "HelloWorld!",
+      "tags": ["squish filter"]
+    },
+    {
+      "name": "just space between",
+      "template": "{{ \"Hello   World!\" | squish }}",
+      "result": "Hello World!",
+      "tags": ["squish filter"]
+    },
+    {
+      "name": "just whitespace",
+      "template": "{{ \" \n\t\r\" | squish }}",
+      "result": "",
+      "tags": ["squish filter"]
+    },
+    {
+      "name": "any whitespace before between and after",
+      "template": "{{ \" \n\t\r\nHello  \n\t\r\n \n\t\r\n World!  \n\t\r\n\" | squish }}",
+      "result": "Hello World!",
+      "tags": ["squish filter"]
+    },
+    {
+      "name": "many words",
+      "template": "{{ \" \n\t\r\nHello  \n\t\r\nthere \n\t\r\nWorld!  \n\t\r\n\" | squish }}",
+      "result": "Hello there World!",
+      "tags": ["squish filter"]
+    },
+    {
+      "name": "line terminators collapse to a single space",
+      "template": "{{ \"Hello\n\t\r\nthere\n\t\r\nWorld!\" | squish }}",
+      "result": "Hello there World!",
+      "tags": ["squish filter"]
+    },
+    {
+      "name": "left is an integer",
+      "template": "{{ 5 | squish }}",
+      "result": "5",
+      "tags": ["squish filter"]
+    },
+    {
+      "name": "left is a float",
+      "template": "{{ 5.2 | squish }}",
+      "result": "5.2",
+      "tags": ["squish filter"]
+    },
+    {
+      "name": "left is null",
+      "template": "{{ null | squish }}",
+      "result": "",
+      "tags": ["squish filter"]
+    },
+    {
+      "name": "left is nil",
+      "template": "{{ nil | squish }}",
+      "result": "",
+      "tags": ["squish filter"]
+    },
+    {
+      "name": "left is false",
+      "template": "{{ false | squish }}",
+      "result": "false",
+      "tags": ["squish filter"]
+    },
+    {
+      "name": "left is true",
+      "template": "{{ true | squish }}",
+      "result": "true",
+      "tags": ["squish filter"]
+    },
+    {
+      "name": "left is undefined",
+      "template": "{{ nosuchthing | squish }}",
+      "result": "",
+      "tags": ["squish filter"]
+    }
+  ]
+}


### PR DESCRIPTION
This PR adds test cases for the `squish` filter, released in [Shopify/liquid v5.12.0](https://github.com/Shopify/liquid/releases/tag/v5.12.0) from https://github.com/Shopify/liquid/pull/2050.

`{{ x | squish }}` is equivalent to `{{ x | strip | split: " " | join }}`

Note that Ruby's `String#split` treats `" "` as "any whitespace" (https://docs.ruby-lang.org/en/master/String.html#method-i-split)

Also note that there's a minor inconsistency with the current implementation of `squish` in Shopify/liquid. Other string filters coerce an input of `nil` to an empty string, `squish` explicitly returns `nil`.