### PR TITLE
Cover strange identifier symbols

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/Shopify/liquid.git
-  revision: 6d81b1b68cf576cc9643ada149c7aa06c25304b8
+  revision: 1954a2655cf4d427b6c9169354832638740f2db5
   branch: main
   specs:
     liquid (5.12.0)

--- a/golden_liquid.json
+++ b/golden_liquid.json
@@ -428,6 +428,36 @@
       ]
     },
     {
+      "name": "identifiers, allowed symbols",
+      "template": "{% assign aA1_-.[] = 'hello' %}{{ [\"aA1_-.[]\"] }}",
+      "data": {},
+      "tags": [
+        "assign tag",
+        "strict"
+      ],
+      "result": "hello"
+    },
+    {
+      "name": "identifiers, allowed symbols, parens",
+      "template": "{% assign (aA1_-.[]) = 'hello' %}{{ [\"(aA1_-.[])\"] }}",
+      "data": {},
+      "tags": [
+        "assign tag",
+        "strict"
+      ],
+      "result": "hello"
+    },
+    {
+      "name": "identifiers, allowed symbols, repeated parens",
+      "template": "{% assign (aA1_-.[])(a)(foo) = 'hello' %}{{ [\"(aA1_-.[])(a)(foo)\"] }}",
+      "data": {},
+      "tags": [
+        "assign tag",
+        "strict"
+      ],
+      "result": "hello"
+    },
+    {
       "name": "identifiers, ascii lowercase",
       "template": "{% assign foo = 'hello' %}{{ foo }} {{ bar }}",
       "data": {
@@ -527,12 +557,12 @@
     },
     {
       "name": "identifiers, capture only digits",
-      "template": "{% capture 123 %}hello{% endcapture %}{{ 123 }}",
+      "template": "{% capture 123 %}hello{% endcapture %}{{ 123 }} {{ [\"123\"] }}",
       "tags": [
         "capture tag",
         "strict"
       ],
-      "result": "123"
+      "result": "123 hello"
     },
     {
       "name": "identifiers, capture only underscore",
@@ -674,7 +704,7 @@
     },
     {
       "name": "identifiers, only digits",
-      "template": "{% assign 123 = 'hello' %}{{ 123 }} {{ 456 }}",
+      "template": "{% assign 123 = 'hello' %}{{ 123 }} {{ 456 }} {{ [\"123\"] }} {{ [\"456\"] }}",
       "data": {
         "456": "goodbye"
       },
@@ -682,7 +712,19 @@
         "assign tag",
         "strict"
       ],
-      "result": "123 456"
+      "result": "123 456 hello goodbye"
+    },
+    {
+      "name": "identifiers, only digits, self",
+      "template": "{% assign 123 = 'hello' %}",
+      "data": {
+        "456": "goodbye"
+      },
+      "tags": [
+        "assign tag",
+        "strict2"
+      ],
+      "invalid": true
     },
     {
       "name": "identifiers, only underscore",
@@ -6721,6 +6763,14 @@
       "name": "filters, squish, left is true",
       "template": "{{ true | squish }}",
       "result": "true",
+      "tags": [
+        "squish filter"
+      ]
+    },
+    {
+      "name": "filters, squish, left is undefined",
+      "template": "{{ nosuchthing | squish }}",
+      "result": "",
       "tags": [
         "squish filter"
       ]

--- a/tests/identifiers.json
+++ b/tests/identifiers.json
@@ -38,7 +38,7 @@
     },
     {
       "name": "only digits",
-      "template": "{% assign 123 = 'hello' %}{{ 123 }} {{ 456 }}",
+      "template": "{% assign 123 = 'hello' %}{{ 123 }} {{ 456 }} {{ [\"123\"] }} {{ [\"456\"] }}",
       "data": {
         "456": "goodbye"
       },
@@ -46,7 +46,49 @@
         "assign tag",
         "strict"
       ],
-      "result": "123 456"
+      "result": "123 456 hello goodbye"
+    },
+    {
+      "name": "allowed symbols",
+      "template": "{% assign aA1_-.[] = 'hello' %}{{ [\"aA1_-.[]\"] }}",
+      "data": {},
+      "tags": [
+        "assign tag",
+        "strict"
+      ],
+      "result": "hello"
+    },
+    {
+      "name": "allowed symbols, parens",
+      "template": "{% assign (aA1_-.[]) = 'hello' %}{{ [\"(aA1_-.[])\"] }}",
+      "data": {},
+      "tags": [
+        "assign tag",
+        "strict"
+      ],
+      "result": "hello"
+    },
+    {
+      "name": "repeated parens",
+      "template": "{% assign (aA1_-.[])(a)(foo) = 'hello' %}{{ [\"(aA1_-.[])(a)(foo)\"] }}",
+      "data": {},
+      "tags": [
+        "assign tag",
+        "strict"
+      ],
+      "result": "hello"
+    },
+    {
+      "name": "only digits, self",
+      "template": "{% assign 123 = 'hello' %}",
+      "data": {
+        "456": "goodbye"
+      },
+      "tags": [
+        "assign tag",
+        "strict2"
+      ],
+      "invalid": true
     },
     {
       "name": "hyphens",
@@ -255,12 +297,12 @@
     },
     {
       "name": "capture only digits",
-      "template": "{% capture 123 %}hello{% endcapture %}{{ 123 }}",
+      "template": "{% capture 123 %}hello{% endcapture %}{{ 123 }} {{ [\"123\"] }}",
       "tags": [
         "capture tag",
         "strict"
       ],
-      "result": "123"
+      "result": "123 hello"
     },
     {
       "name": "capture hyphens",


### PR DESCRIPTION
This PR adds tests covering some non alphabetic symbols allowed when creating variables with the `{% assign %}` tag.

Although the `{% assign %}` tag accepts these symbols in lax and strict mode (not strict2 mode), the only way to access them is with a root bracketed segment. For example, this is valid and results in `hello`:

```
{% assign (aA1_-.[]) = 'hello' %}{{ ["(aA1_-.[])"] }}
```

There's probably some historical reason for why these symbols are allowed. I include these test here mostly for the sake of documentation, and I expect most implementers will choose to skip them. 