### PR TITLE
Tighten `first` and `last` results

### DIFF
--- a/golden_liquid.json
+++ b/golden_liquid.json
@@ -448,16 +448,6 @@
       "result": "hello"
     },
     {
-      "name": "identifiers, allowed symbols, repeated parens",
-      "template": "{% assign (aA1_-.[])(a)(foo) = 'hello' %}{{ [\"(aA1_-.[])(a)(foo)\"] }}",
-      "data": {},
-      "tags": [
-        "assign tag",
-        "strict"
-      ],
-      "result": "hello"
-    },
-    {
       "name": "identifiers, ascii lowercase",
       "template": "{% assign foo = 'hello' %}{{ foo }} {{ bar }}",
       "data": {
@@ -737,6 +727,16 @@
         "strict"
       ],
       "result": "hello goodbye"
+    },
+    {
+      "name": "identifiers, repeated parens",
+      "template": "{% assign (aA1_-.[])(a)(foo) = 'hello' %}{{ [\"(aA1_-.[])(a)(foo)\"] }}",
+      "data": {},
+      "tags": [
+        "assign tag",
+        "strict"
+      ],
+      "result": "hello"
     },
     {
       "name": "identifiers, trailing question mark assign",
@@ -1418,10 +1418,7 @@
       "data": {
         "s": "hello"
       },
-      "results": [
-        "h",
-        ""
-      ]
+      "result": "h"
     },
     {
       "name": "special, first of an array",
@@ -1488,10 +1485,7 @@
       "data": {
         "s": "hello"
       },
-      "results": [
-        "o",
-        ""
-      ]
+      "result": "o"
     },
     {
       "name": "special, last of an array",
@@ -3591,10 +3585,7 @@
     {
       "name": "filters, first, first of a string",
       "template": "{{ 'hello' | first }}",
-      "results": [
-        "",
-        "h"
-      ],
+      "result": "h",
       "tags": [
         "first filter"
       ]
@@ -4234,10 +4225,7 @@
     {
       "name": "filters, last, last of a string",
       "template": "{{ 'hello' | last }}",
-      "results": [
-        "",
-        "o"
-      ],
+      "result": "o",
       "tags": [
         "last filter"
       ]

--- a/tests/filters/first.json
+++ b/tests/filters/first.json
@@ -72,10 +72,7 @@
     {
       "name": "first of a string",
       "template": "{{ 'hello' | first }}",
-      "results": [
-        "",
-        "h"
-      ],
+      "result": "h",
       "tags": [
         "first filter"
       ]

--- a/tests/filters/last.json
+++ b/tests/filters/last.json
@@ -72,10 +72,7 @@
     {
       "name": "last of a string",
       "template": "{{ 'hello' | last }}",
-      "results": [
-        "",
-        "o"
-      ],
+      "result": "o",
       "tags": [
         "last filter"
       ]

--- a/tests/special.json
+++ b/tests/special.json
@@ -50,10 +50,7 @@
       "data": {
         "s": "hello"
       },
-      "results": [
-        "h",
-        ""
-      ]
+      "result": "h"
     },
     {
       "name": "first of an object",
@@ -86,10 +83,7 @@
       "data": {
         "s": "hello"
       },
-      "results": [
-        "o",
-        ""
-      ]
+      "result": "o"
     },
     {
       "name": "last of a object",


### PR DESCRIPTION
Since Shopify/liquid v5.12 and https://github.com/Shopify/liquid/pull/2034, `first` and `last` filters - and the special `.first` and `.last` properties - now operate consistently on strings. Previously it would depend on the presence of Active Support.

This PR replaces the `results` array for those test case with a single `result`.