### PR TITLE
Add more range tests

### DIFF
--- a/golden_liquid.json
+++ b/golden_liquid.json
@@ -1442,6 +1442,25 @@
       ]
     },
     {
+      "name": "range, float from a variable is an error",
+      "template": "{{ (x..5) | join: '#' }}",
+      "data": {
+        "x": 2.3
+      },
+      "invalid": true,
+      "tags": [
+        "join filter"
+      ]
+    },
+    {
+      "name": "range, float literal is truncated",
+      "template": "{{ (2.3..5) | join: '#' }}",
+      "result": "2#3#4#5",
+      "tags": [
+        "join filter"
+      ]
+    },
+    {
       "name": "range, integer literals",
       "template": "{{ (1..5) | join: '#' }}",
       "result": "1#2#3#4#5",

--- a/golden_liquid.json
+++ b/golden_liquid.json
@@ -76,6 +76,21 @@
       ]
     },
     {
+      "name": "blank and empty, blank as a variable segment is not a reserved word",
+      "template": "{{ a.blank.b }}",
+      "data": {
+        "a": {
+          "blank": {
+            "b": 42
+          }
+        }
+      },
+      "result": "42",
+      "tags": [
+        "blank"
+      ]
+    },
+    {
       "name": "blank and empty, blank coerces to an empty string",
       "template": "{{ blank | split: '' | join: '-' }}",
       "data": {},
@@ -1446,6 +1461,31 @@
       "template": "{{ (1..5) | join: '#' }}",
       "result": "1#2#3#4#5",
       "tags": [
+        "join filter"
+      ]
+    },
+    {
+      "name": "range, slice uses range string representation",
+      "template": "{{ (1..5) | slice: 1, 3 }}",
+      "tags": [
+        "slice filter"
+      ],
+      "result": "..5"
+    },
+    {
+      "name": "range, start and end are equal",
+      "template": "{{ (2..2) | join: '#' }}",
+      "result": "2",
+      "tags": [
+        "join filter"
+      ]
+    },
+    {
+      "name": "range, start and end are equal, for loop",
+      "template": "{% for x in (2..2) %}{{ x }},{% endfor %}",
+      "result": "2,",
+      "tags": [
+        "for tag",
         "join filter"
       ]
     },

--- a/golden_liquid.json
+++ b/golden_liquid.json
@@ -76,21 +76,6 @@
       ]
     },
     {
-      "name": "blank and empty, blank as a variable segment is not a reserved word",
-      "template": "{{ a.blank.b }}",
-      "data": {
-        "a": {
-          "blank": {
-            "b": 42
-          }
-        }
-      },
-      "result": "42",
-      "tags": [
-        "blank"
-      ]
-    },
-    {
       "name": "blank and empty, blank coerces to an empty string",
       "template": "{{ blank | split: '' | join: '-' }}",
       "data": {},
@@ -9824,6 +9809,46 @@
         }
       },
       "result": "0 - sports 1 - garden ",
+      "tags": [
+        "for tag"
+      ]
+    },
+    {
+      "name": "tags, for, range loop, negative offset",
+      "template": "{% for i in (0..3) offset: -2 %}{{ i }} {% endfor %}",
+      "result": "0 1 2 3 ",
+      "tags": [
+        "for tag"
+      ]
+    },
+    {
+      "name": "tags, for, range loop, negative offset, continue",
+      "template": "{% for i in (0..3) offset: -2 %}a{{ i }} {% endfor %}{% for i in (0..3) offset: continue %}b{{ i }} {% endfor %}",
+      "result": "a0 a1 a2 a3 b2 b3 ",
+      "tags": [
+        "for tag"
+      ]
+    },
+    {
+      "name": "tags, for, range loop, negative offset, limit",
+      "template": "{% for i in (0..3) offset: -2 limit: 3 %}{{ i }} {% endfor %}",
+      "result": "0 ",
+      "tags": [
+        "for tag"
+      ]
+    },
+    {
+      "name": "tags, for, range loop, negative offset, negative limit",
+      "template": "{% for i in (0..5) offset: -2 limit: -1 %}{{ i }} {% endfor %}",
+      "result": "",
+      "tags": [
+        "for tag"
+      ]
+    },
+    {
+      "name": "tags, for, range loop, offset, negative limit",
+      "template": "{% for i in (0..5) offset: 1 limit: -1 %}{{ i }} {% endfor %}",
+      "result": "",
       "tags": [
         "for tag"
       ]

--- a/tests/range.json
+++ b/tests/range.json
@@ -141,6 +141,25 @@
         "slice filter"
       ],
       "result": "..5"
+    },
+    {
+      "name": "float literal is truncated",
+      "template": "{{ (2.3..5) | join: '#' }}",
+      "result": "2#3#4#5",
+      "tags": [
+        "join filter"
+      ]
+    },
+    {
+      "name": "float from a variable is an error",
+      "template": "{{ (x..5) | join: '#' }}",
+      "data": {
+        "x": 2.3
+      },
+      "invalid": true,
+      "tags": [
+        "join filter"
+      ]
     }
   ]
 }

--- a/tests/range.json
+++ b/tests/range.json
@@ -61,6 +61,23 @@
       ]
     },
     {
+      "name": "start and end are equal",
+      "template": "{{ (2..2) | join: '#' }}",
+      "result": "2",
+      "tags": [
+        "join filter"
+      ]
+    },
+    {
+      "name": "start and end are equal, for loop",
+      "template": "{% for x in (2..2) %}{{ x }},{% endfor %}",
+      "result": "2,",
+      "tags": [
+        "join filter",
+        "for tag"
+      ]
+    },
+    {
       "name": "integer literals",
       "template": "{{ (1..5) | join: '#' }}",
       "result": "1#2#3#4#5",
@@ -116,6 +133,14 @@
         "strict"
       ],
       "result": "1,2,3,4,5,"
+    },
+    {
+      "name": "slice uses range string representation",
+      "template": "{{ (1..5) | slice: 1, 3 }}",
+      "tags": [
+        "slice filter"
+      ],
+      "result": "..5"
     }
   ]
 }

--- a/tests/tags/for.json
+++ b/tests/tags/for.json
@@ -887,6 +887,46 @@
       "tags": [
         "for tag"
       ]
+    },
+    {
+      "name": "range loop, negative offset",
+      "template": "{% for i in (0..3) offset: -2 %}{{ i }} {% endfor %}",
+      "result": "0 1 2 3 ",
+      "tags": [
+        "for tag"
+      ]
+    },
+    {
+      "name": "range loop, negative offset, continue",
+      "template": "{% for i in (0..3) offset: -2 %}a{{ i }} {% endfor %}{% for i in (0..3) offset: continue %}b{{ i }} {% endfor %}",
+      "result": "a0 a1 a2 a3 b2 b3 ",
+      "tags": [
+        "for tag"
+      ]
+    },
+    {
+      "name": "range loop, negative offset, limit",
+      "template": "{% for i in (0..3) offset: -2 limit: 3 %}{{ i }} {% endfor %}",
+      "result": "0 ",
+      "tags": [
+        "for tag"
+      ]
+    },
+    {
+      "name": "range loop, offset, negative limit",
+      "template": "{% for i in (0..5) offset: 1 limit: -1 %}{{ i }} {% endfor %}",
+      "result": "",
+      "tags": [
+        "for tag"
+      ]
+    },
+    {
+      "name": "range loop, negative offset, negative limit",
+      "template": "{% for i in (0..5) offset: -2 limit: -1 %}{{ i }} {% endfor %}",
+      "result": "",
+      "tags": [
+        "for tag"
+      ]
     }
   ]
 }


### PR DESCRIPTION
Test:

- that a range literal with equal begin and end values yields exactly one value.
- that the `slice` filter slices on the string representation of a range literal.
- that float literals and variables pointing to float values are evaluated differently in range expressions.
- negative `offset` and `limit` `{% for %}` tag arguments.